### PR TITLE
Implement content scheduling with time-based playlist assignment (fix…

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,7 +43,7 @@ Implementation plan for completing incomplete features and improving the app. Is
 
 ## Phase 5 — New Features
 
-- [ ] **[#19](https://github.com/glensouza/PlainSight/issues/19) Content scheduling: time-based playlist assignment**
+- [x] **[#19](https://github.com/glensouza/PlainSight/issues/19) Content scheduling: time-based playlist assignment**
   No way to schedule which playlist plays when. Add a `Schedule` table (playlist, device group, days of week, time range, priority). `ScheduleService` returns the active playlist for a group at the current time. Heartbeat response includes the active file list; player switches content when it changes. New Schedule admin page. *(Depends on #13)*
 
 - [ ] **[#20](https://github.com/glensouza/PlainSight/issues/20) Device offline alerts via email**
@@ -90,6 +90,6 @@ Implementation plan for completing incomplete features and improving the app. Is
 | 6 | #17 | Depends on #16 | ✅ Done |
 | 7 | #18 | Depends on #12 | ✅ Done |
 | 8 | #20 | Standalone; no blockers | |
-| 9 | #19 | Depends on #13 | |
+| 9 | #19 | Depends on #13 | ✅ Done |
 | 10 | #21 | Depends on #14 | |
 | 11 | #22 | Depends on #13 and #14 | |

--- a/src/PlainSight.Player/PlayerWorker.cs
+++ b/src/PlainSight.Player/PlayerWorker.cs
@@ -26,6 +26,9 @@ public class PlayerWorker(
         {
             try
             {
+                // Sync from SMB to local cache on each heartbeat cadence
+                await cache.SyncAsync(stoppingToken);
+
                 HeartbeatResponse? response = await heartbeat.SendHeartbeat(playlist.GetCurrentFile(), stoppingToken);
 
                 if (response != null)
@@ -45,11 +48,22 @@ public class PlayerWorker(
                         else
                             logger.LogWarning("Screenshot capture returned empty result; skipping upload");
                     }
-                }
 
-                // Sync and refresh playlist on the same cadence as the heartbeat
-                await cache.SyncAsync(stoppingToken);
-                await playlist.RefreshAsync(stoppingToken);
+                    if (response.PlaylistFiles != null)
+                    {
+                        playlist.UpdatePlaylist(response.PlaylistFiles);
+                    }
+                    else
+                    {
+                        // No scheduled playlist from server, refresh from the local playlist.json (synced from SMB)
+                        await playlist.RefreshAsync(stoppingToken);
+                    }
+                }
+                else
+                {
+                    // Fallback to disk if heartbeat fails
+                    await playlist.RefreshAsync(stoppingToken);
+                }
 
                 await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
             }

--- a/src/PlainSight.Player/PlayerWorker.cs
+++ b/src/PlainSight.Player/PlayerWorker.cs
@@ -26,9 +26,6 @@ public class PlayerWorker(
         {
             try
             {
-                // Sync from SMB to local cache on each heartbeat cadence
-                await cache.SyncAsync(stoppingToken);
-
                 HeartbeatResponse? response = await heartbeat.SendHeartbeat(playlist.GetCurrentFile(), stoppingToken);
 
                 if (response != null)
@@ -63,6 +60,16 @@ public class PlayerWorker(
                 {
                     // Fallback to disk if heartbeat fails
                     await playlist.RefreshAsync(stoppingToken);
+                }
+
+                // Sync from SMB to local cache; isolated so an SMB outage doesn't suppress the heartbeat
+                try
+                {
+                    await cache.SyncAsync(stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "SMB cache sync failed; continuing with cached content");
                 }
 
                 await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);

--- a/src/PlainSight.Player/Services/PlaylistService.cs
+++ b/src/PlainSight.Player/Services/PlaylistService.cs
@@ -73,6 +73,24 @@ public class PlaylistService
         }
     }
 
+    public void UpdatePlaylist(List<string> filenames)
+    {
+        List<string> validFiles = filenames
+            .Where(f => IsValidFilename(f))
+            .Where(f => VideoFormats.SupportedExtensions.Contains(Path.GetExtension(f).ToLowerInvariant()))
+            .ToList();
+
+        lock (_lock)
+        {
+            // Only update and log if the playlist has actually changed
+            if (!_playlist.SequenceEqual(validFiles))
+            {
+                _playlist = validFiles;
+                _logger.LogInformation("Playlist updated via heartbeat: {Count} item(s)", _playlist.Count);
+            }
+        }
+    }
+
     public IReadOnlyList<string> GetCurrentPlaylist()
     {
         lock (_lock)

--- a/src/PlainSight.Server/Api/DeviceApi.cs
+++ b/src/PlainSight.Server/Api/DeviceApi.cs
@@ -30,7 +30,7 @@ public static class DeviceApi
     {
         RouteGroupBuilder group = routes.MapGroup("/api/device");
 
-        group.MapPost("/heartbeat", async (DeviceTelemetryDto data, HttpContext httpContext, PlainSightDbContext context, VersionService versionService, ILoggerFactory loggerFactory, CancellationToken ct) =>
+        group.MapPost("/heartbeat", async (DeviceTelemetryDto data, HttpContext httpContext, PlainSightDbContext context, VersionService versionService, ScheduleService scheduleService, ILoggerFactory loggerFactory, CancellationToken ct) =>
         {
             ILogger logger = loggerFactory.CreateLogger("DeviceApi");
             try
@@ -87,6 +87,13 @@ public static class DeviceApi
                 // Check for "Canary" Update assignment
                 string targetVersion = await versionService.GetTargetVersionAsync(device.Group, ct);
 
+                // Check for Scheduled Playlist
+                Playlist? activePlaylist = await scheduleService.GetActivePlaylistAsync(device.Group, DateTime.UtcNow);
+                List<string>? playlistFiles = activePlaylist?.Items
+                    .OrderBy(i => i.Order)
+                    .Select(i => i.ContentItem.FileName)
+                    .ToList();
+
                 HeartbeatResponse response = new()
                 {
                     // Command Flags
@@ -94,7 +101,8 @@ public static class DeviceApi
                     UpdateUrl = device.CurrentVersion != targetVersion
                         ? $"/api/updates/{targetVersion}/binary"
                         : null,
-                    AssignedApiKey = assignedApiKey
+                    AssignedApiKey = assignedApiKey,
+                    PlaylistFiles = playlistFiles
                 };
 
                 // Reset screenshot request
@@ -303,6 +311,28 @@ public static class DeviceApi
             return Results.Ok();
         }).RequireAuthorization();
 
+        group.MapPut("/{deviceId}/group", async (
+            string deviceId,
+            DeviceGroupUpdateRequest request,
+            PlainSightDbContext context,
+            ILoggerFactory loggerFactory,
+            CancellationToken ct) =>
+        {
+            ILogger logger = loggerFactory.CreateLogger("DeviceApi");
+            Device? device = await context.Devices.FirstOrDefaultAsync(d => d.DeviceId == deviceId, ct);
+            if (device == null)
+                return Results.NotFound();
+
+            string oldGroup = device.Group;
+            device.Group = request.Group;
+            await context.SaveChangesAsync(ct);
+
+            logger.LogInformation("Device {DeviceId} moved from group {OldGroup} to {NewGroup}", deviceId, oldGroup, request.Group);
+            return Results.Ok();
+        }).RequireAuthorization();
+
         return group;
     }
 }
+
+public record DeviceGroupUpdateRequest(string Group);

--- a/src/PlainSight.Server/Api/ScheduleApi.cs
+++ b/src/PlainSight.Server/Api/ScheduleApi.cs
@@ -17,11 +17,11 @@ public static class ScheduleApi
                 .Include(s => s.TargetGroups)
                 .OrderBy(s => s.StartTime)
                 .ToListAsync(ct);
-            
-            return Results.Ok(schedules);
-        });
 
-        group.MapPost("/", async (ScheduleCreateDto dto, PlainSightDbContext context) =>
+            return Results.Ok(schedules);
+        }).RequireAuthorization();
+
+        group.MapPost("/", async (ScheduleCreateDto dto, PlainSightDbContext context, CancellationToken ct) =>
         {
             Schedule schedule = new()
             {
@@ -44,17 +44,17 @@ public static class ScheduleApi
             }
 
             context.Schedules.Add(schedule);
-            await context.SaveChangesAsync();
+            await context.SaveChangesAsync(ct);
 
             return Results.Ok(schedule);
-        });
+        }).RequireAuthorization();
 
-        group.MapPut("/{id:int}", async (int id, ScheduleCreateDto dto, PlainSightDbContext context) =>
+        group.MapPut("/{id:int}", async (int id, ScheduleCreateDto dto, PlainSightDbContext context, CancellationToken ct) =>
         {
             Schedule? schedule = await context.Schedules
                 .Include(s => s.TargetGroups)
-                .FirstOrDefaultAsync(s => s.Id == id);
-            
+                .FirstOrDefaultAsync(s => s.Id == id, ct);
+
             if (schedule == null)
                 return Results.NotFound();
 
@@ -77,20 +77,20 @@ public static class ScheduleApi
                 }
             }
 
-            await context.SaveChangesAsync();
+            await context.SaveChangesAsync(ct);
             return Results.Ok(schedule);
-        });
+        }).RequireAuthorization();
 
-        group.MapDelete("/{id:int}", async (int id, PlainSightDbContext context) =>
+        group.MapDelete("/{id:int}", async (int id, PlainSightDbContext context, CancellationToken ct) =>
         {
-            Schedule? schedule = await context.Schedules.FindAsync(id);
+            Schedule? schedule = await context.Schedules.FindAsync([id], ct);
             if (schedule == null)
                 return Results.NotFound();
 
             context.Schedules.Remove(schedule);
-            await context.SaveChangesAsync();
+            await context.SaveChangesAsync(ct);
             return Results.Ok();
-        });
+        }).RequireAuthorization();
 
         return group;
     }

--- a/src/PlainSight.Server/Api/ScheduleApi.cs
+++ b/src/PlainSight.Server/Api/ScheduleApi.cs
@@ -1,0 +1,108 @@
+using Microsoft.EntityFrameworkCore;
+using PlainSight.Server.Data;
+using PlainSight.Shared.Models;
+
+namespace PlainSight.Server.Api;
+
+public static class ScheduleApi
+{
+    public static RouteGroupBuilder MapScheduleApi(this IEndpointRouteBuilder routes)
+    {
+        RouteGroupBuilder group = routes.MapGroup("/api/schedules");
+
+        group.MapGet("/", async (PlainSightDbContext context, CancellationToken ct) =>
+        {
+            List<Schedule> schedules = await context.Schedules
+                .Include(s => s.Playlist)
+                .Include(s => s.TargetGroups)
+                .OrderBy(s => s.StartTime)
+                .ToListAsync(ct);
+            
+            return Results.Ok(schedules);
+        });
+
+        group.MapPost("/", async (ScheduleCreateDto dto, PlainSightDbContext context) =>
+        {
+            Schedule schedule = new()
+            {
+                Name = dto.Name,
+                PlaylistId = dto.PlaylistId,
+                DaysOfWeek = dto.DaysOfWeek,
+                ScheduledDate = dto.ScheduledDate,
+                StartTime = dto.StartTime,
+                EndTime = dto.EndTime,
+                Priority = dto.Priority,
+                IsActive = dto.IsActive
+            };
+
+            if (dto.TargetGroups != null)
+            {
+                foreach (string groupName in dto.TargetGroups)
+                {
+                    schedule.TargetGroups.Add(new ScheduleTargetGroup { GroupName = groupName });
+                }
+            }
+
+            context.Schedules.Add(schedule);
+            await context.SaveChangesAsync();
+
+            return Results.Ok(schedule);
+        });
+
+        group.MapPut("/{id:int}", async (int id, ScheduleCreateDto dto, PlainSightDbContext context) =>
+        {
+            Schedule? schedule = await context.Schedules
+                .Include(s => s.TargetGroups)
+                .FirstOrDefaultAsync(s => s.Id == id);
+            
+            if (schedule == null)
+                return Results.NotFound();
+
+            schedule.Name = dto.Name;
+            schedule.PlaylistId = dto.PlaylistId;
+            schedule.DaysOfWeek = dto.DaysOfWeek;
+            schedule.ScheduledDate = dto.ScheduledDate;
+            schedule.StartTime = dto.StartTime;
+            schedule.EndTime = dto.EndTime;
+            schedule.Priority = dto.Priority;
+            schedule.IsActive = dto.IsActive;
+
+            // Sync target groups
+            schedule.TargetGroups.Clear();
+            if (dto.TargetGroups != null)
+            {
+                foreach (string groupName in dto.TargetGroups)
+                {
+                    schedule.TargetGroups.Add(new ScheduleTargetGroup { GroupName = groupName });
+                }
+            }
+
+            await context.SaveChangesAsync();
+            return Results.Ok(schedule);
+        });
+
+        group.MapDelete("/{id:int}", async (int id, PlainSightDbContext context) =>
+        {
+            Schedule? schedule = await context.Schedules.FindAsync(id);
+            if (schedule == null)
+                return Results.NotFound();
+
+            context.Schedules.Remove(schedule);
+            await context.SaveChangesAsync();
+            return Results.Ok();
+        });
+
+        return group;
+    }
+}
+
+public record ScheduleCreateDto(
+    string Name,
+    int PlaylistId,
+    List<string>? TargetGroups,
+    DayOfWeekFlags DaysOfWeek,
+    DateOnly? ScheduledDate,
+    TimeOnly StartTime,
+    TimeOnly EndTime,
+    int Priority,
+    bool IsActive);

--- a/src/PlainSight.Server/Api/ScheduleApi.cs
+++ b/src/PlainSight.Server/Api/ScheduleApi.cs
@@ -19,7 +19,7 @@ public static class ScheduleApi
                 .ToListAsync(ct);
 
             return Results.Ok(schedules);
-        }).RequireAuthorization();
+        });
 
         group.MapPost("/", async (ScheduleCreateDto dto, PlainSightDbContext context, CancellationToken ct) =>
         {

--- a/src/PlainSight.Server/Api/VersionApi.cs
+++ b/src/PlainSight.Server/Api/VersionApi.cs
@@ -118,14 +118,19 @@ public static class VersionApi
             if (string.IsNullOrWhiteSpace(groupName) || string.IsNullOrWhiteSpace(request.TargetVersion))
                 return Results.BadRequest("Group name and target version are required");
 
-            // Validate version exists
-            bool versionExists = await context.PlayerVersions
-                .AnyAsync(v => v.VersionNumber == request.TargetVersion, ct);
-            if (!versionExists)
-                return Results.BadRequest($"Version {request.TargetVersion} does not exist");
-
             DeviceGroupVersion? existing = await context.DeviceGroupVersions
                 .FirstOrDefaultAsync(g => g.GroupName == groupName, ct);
+
+            // Validate version exists if it's changing OR if it's a new group
+            if (existing == null || existing.TargetVersion != request.TargetVersion)
+            {
+                bool versionExists = await context.PlayerVersions
+                    .AnyAsync(v => v.VersionNumber == request.TargetVersion, ct);
+                
+                // Allow "1.0.0" as a fallback if no versions exist yet (bootstrap case)
+                if (!versionExists && request.TargetVersion != "1.0.0")
+                    return Results.BadRequest($"Version {request.TargetVersion} does not exist");
+            }
 
             if (existing == null)
             {
@@ -134,6 +139,7 @@ public static class VersionApi
             }
 
             existing.TargetVersion = request.TargetVersion;
+            existing.DefaultPlaylistId = request.DefaultPlaylistId;
             await context.SaveChangesAsync(ct);
 
             return Results.Ok(existing);
@@ -159,4 +165,4 @@ public static class VersionApi
     }
 }
 
-public sealed record GroupVersionRequest(string TargetVersion);
+public sealed record GroupVersionRequest(string TargetVersion, int? DefaultPlaylistId = null);

--- a/src/PlainSight.Server/Components/Layout/NavMenu.razor
+++ b/src/PlainSight.Server/Components/Layout/NavMenu.razor
@@ -39,6 +39,12 @@
         </div>
 
         <div class="nav-item">
+            <NavLink class="nav-link" href="schedules">
+                <i class="bi bi-calendar3"></i> Schedule
+            </NavLink>
+        </div>
+
+        <div class="nav-item">
             <NavLink class="nav-link" href="versions">
                 <i class="bi bi-box-seam"></i> Versions
             </NavLink>

--- a/src/PlainSight.Server/Components/Pages/Devices.razor
+++ b/src/PlainSight.Server/Components/Pages/Devices.razor
@@ -60,7 +60,23 @@ else
                         </td>
                         <td><code>@device.DeviceId</code></td>
                         <td>@device.Name</td>
-                        <td><span class="badge bg-primary">@device.Group</span></td>
+                        <td>
+                            <select class="form-select form-select-sm"
+                                    value="@device.Group"
+                                    @onchange="e => ChangeGroup(device.DeviceId, e.Value?.ToString() ?? device.Group)">
+                                @if (groups != null)
+                                {
+                                    @foreach (var g in groups)
+                                    {
+                                        <option value="@g.GroupName">@g.GroupName</option>
+                                    }
+                                }
+                                else
+                                {
+                                    <option value="@device.Group">@device.Group</option>
+                                }
+                            </select>
+                        </td>
                         <td>
                             <span title="@device.LastSeen.ToString("yyyy-MM-dd HH:mm:ss")">
                                 @GetTimeSince(device.LastSeen)
@@ -159,6 +175,7 @@ else
 
 @code {
     private List<Device>? devices;
+    private List<DeviceGroupVersion>? groups;
     private HashSet<string> requestingScreenshot = new();
     private HashSet<string> resettingApiKey = new();
     private Timer? refreshTimer;
@@ -188,11 +205,33 @@ else
         try
         {
             devices = await httpClient!.GetFromJsonAsync<List<Device>>("/api/device");
+            groups = await httpClient!.GetFromJsonAsync<List<DeviceGroupVersion>>("/api/versions/groups");
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Error loading devices");
+            Logger.LogError(ex, "Error loading devices or groups");
             devices = new List<Device>();
+        }
+    }
+
+    private async Task ChangeGroup(string deviceId, string newGroup)
+    {
+        try
+        {
+            HttpResponseMessage response = await httpClient!.PutAsJsonAsync($"/api/device/{deviceId}/group", new { Group = newGroup });
+            if (response.IsSuccessStatusCode)
+            {
+                Logger.LogInformation("Device {DeviceId} moved to group {Group}", deviceId, newGroup);
+                await LoadDevices();
+            }
+            else
+            {
+                Logger.LogWarning("Failed to change group for device {DeviceId}", deviceId);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error changing group for device {DeviceId}", deviceId);
         }
     }
 

--- a/src/PlainSight.Server/Components/Pages/Devices.razor
+++ b/src/PlainSight.Server/Components/Pages/Devices.razor
@@ -66,7 +66,7 @@ else
                                     @onchange="e => ChangeGroup(device.DeviceId, e.Value?.ToString() ?? device.Group)">
                                 @if (groups != null)
                                 {
-                                    @foreach (var g in groups)
+                                    @foreach (DeviceGroupVersion g in groups)
                                     {
                                         <option value="@g.GroupName">@g.GroupName</option>
                                     }

--- a/src/PlainSight.Server/Components/Pages/Playlists.razor
+++ b/src/PlainSight.Server/Components/Pages/Playlists.razor
@@ -338,7 +338,7 @@ else
 
         try
         {
-            var itemData = new { ContentItemId = selectedContentId };
+            AddPlaylistItemRequest itemData = new(selectedContentId);
             HttpResponseMessage response = await httpClient!.PostAsJsonAsync($"/api/playlists/{managingPlaylistId.Value}/items", itemData);
             
             if (response.IsSuccessStatusCode)
@@ -375,4 +375,6 @@ else
     {
         // Cleanup if needed
     }
+
+    private record AddPlaylistItemRequest(int ContentItemId);
 }

--- a/src/PlainSight.Server/Components/Pages/Playlists.razor
+++ b/src/PlainSight.Server/Components/Pages/Playlists.razor
@@ -152,6 +152,38 @@ else
                     {
                         <p class="text-muted">No items in this playlist yet.</p>
                     }
+
+                    <hr />
+                    <h6>Add Content</h6>
+                    @if (availableContent == null)
+                    {
+                        <p><em>Loading available content...</em></p>
+                    }
+                    else if (!availableContent.Any())
+                    {
+                        <div class="alert alert-warning py-2 small">
+                            No content available. Upload videos in the <a href="content">Content</a> page first.
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="row g-2">
+                            <div class="col-md-8">
+                                <select class="form-select form-select-sm" @bind="selectedContentId">
+                                    <option value="0">Select content to add...</option>
+                                    @foreach (var content in availableContent)
+                                    {
+                                        <option value="@content.Id">@content.Name (@content.DurationSeconds s)</option>
+                                    }
+                                </select>
+                            </div>
+                            <div class="col-md-4">
+                                <button class="btn btn-sm btn-success w-100" @onclick="AddToPlaylist" disabled="@(selectedContentId == 0)">
+                                    <i class="bi bi-plus"></i> Add to Playlist
+                                </button>
+                            </div>
+                        </div>
+                    }
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" @onclick="CloseManageItems">Close</button>
@@ -171,6 +203,8 @@ else
     private bool playlistIsActive = true;
     private int? managingPlaylistId;
     private Playlist? selectedPlaylist;
+    private List<ContentItem>? availableContent;
+    private int selectedContentId;
 
     protected override async Task OnInitializedAsync()
     {
@@ -282,10 +316,12 @@ else
         try
         {
             selectedPlaylist = await httpClient!.GetFromJsonAsync<Playlist>($"/api/playlists/{playlistId}");
+            availableContent = await httpClient!.GetFromJsonAsync<List<ContentItem>>("/api/content");
+            selectedContentId = 0;
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Error loading playlist items");
+            Logger.LogError(ex, "Error loading playlist items or available content");
         }
     }
 
@@ -293,6 +329,29 @@ else
     {
         managingPlaylistId = null;
         selectedPlaylist = null;
+        availableContent = null;
+    }
+
+    private async Task AddToPlaylist()
+    {
+        if (selectedContentId == 0 || !managingPlaylistId.HasValue) return;
+
+        try
+        {
+            var itemData = new { ContentItemId = selectedContentId };
+            HttpResponseMessage response = await httpClient!.PostAsJsonAsync($"/api/playlists/{managingPlaylistId.Value}/items", itemData);
+            
+            if (response.IsSuccessStatusCode)
+            {
+                selectedContentId = 0;
+                await ManagePlaylistItems(managingPlaylistId.Value);
+                await LoadPlaylists();
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error adding item to playlist");
+        }
     }
 
     private async Task RemoveFromPlaylist(int playlistItemId)

--- a/src/PlainSight.Server/Components/Pages/Schedules.razor
+++ b/src/PlainSight.Server/Components/Pages/Schedules.razor
@@ -1,0 +1,514 @@
+@page "/schedules"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@inject IHttpClientFactory HttpClientFactory
+@inject NavigationManager Navigation
+@inject IJSRuntime JS
+@inject ILogger<Schedules> Logger
+@using PlainSight.Shared.Models
+@implements IDisposable
+
+<PageTitle>Schedules — PlainSight</PageTitle>
+
+<div class="page-header d-flex justify-content-between align-items-end">
+    <div>
+        <h1>Content Schedule</h1>
+        <p class="text-muted mb-0">Define which playlists play on specific days and times</p>
+    </div>
+    <button class="btn btn-primary" @onclick="ShowCreateSchedule">
+        <i class="bi bi-calendar-plus me-1"></i> New Schedule
+    </button>
+</div>
+
+@if (loadError != null)
+{
+    <div class="alert alert-danger mb-4"><i class="bi bi-exclamation-triangle"></i> @loadError</div>
+}
+
+<div class="card mb-4">
+    <div class="card-body p-0">
+        @if (schedules == null)
+        {
+            <div class="p-4 text-center">
+                <div class="spinner-border text-primary" role="status"></div>
+                <div class="mt-2 text-muted">Loading schedules...</div>
+            </div>
+        }
+        else if (schedules.Count == 0)
+        {
+            <div class="p-5 text-center">
+                <i class="bi bi-calendar-x text-muted display-4"></i>
+                <p class="mt-3 text-muted">No schedules defined yet. Create one to get started.</p>
+            </div>
+        }
+        else
+        {
+            <div class="table-responsive">
+                <table class="table table-hover align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Target Groups</th>
+                            <th>Playlist</th>
+                            <th>Schedule Type</th>
+                            <th>Time Range</th>
+                            <th>Priority</th>
+                            <th>Status</th>
+                            <th class="text-end">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var s in schedules)
+                        {
+                            <tr>
+                                <td><strong>@s.Name</strong></td>
+                                <td>
+                                    @if (s.TargetGroups == null || s.TargetGroups.Count == 0)
+                                    {
+                                        <span class="badge bg-secondary">All Groups</span>
+                                    }
+                                    else
+                                    {
+                                        <div class="d-flex gap-1 flex-wrap" style="max-width: 250px;">
+                                            @foreach (var tg in s.TargetGroups)
+                                            {
+                                                <span class="badge bg-info text-dark">@tg.GroupName</span>
+                                            }
+                                        </div>
+                                    }
+                                </td>
+                                <td><i class="bi bi-collection-play me-1"></i> @s.Playlist?.Name</td>
+                                <td>
+                                    @if (s.ScheduledDate.HasValue)
+                                    {
+                                        <span class="badge bg-primary-subtle text-primary border border-primary-subtle">
+                                            <i class="bi bi-calendar-event me-1"></i> @s.ScheduledDate.Value.ToString("yyyy-MM-dd")
+                                        </span>
+                                    }
+                                    else
+                                    {
+                                        <div class="d-flex gap-1 flex-wrap" style="max-width: 200px;">
+                                            @foreach (var day in GetActiveDays(s.DaysOfWeek))
+                                            {
+                                                <span class="badge bg-light text-dark border">@day</span>
+                                            }
+                                        </div>
+                                    }
+                                </td>
+                                <td>
+                                    <code>@s.StartTime.ToString("HH:mm")</code> – <code>@s.EndTime.ToString("HH:mm")</code>
+                                </td>
+                                <td>@s.Priority</td>
+                                <td>
+                                    @if (s.IsActive)
+                                    {
+                                        <span class="badge bg-success-subtle text-success border border-success-subtle">Active</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="badge bg-secondary-subtle text-secondary border border-secondary-subtle">Inactive</span>
+                                    }
+                                </td>
+                                <td class="text-end">
+                                    <button class="btn btn-sm btn-outline-primary me-1" @onclick="() => EditSchedule(s)">
+                                        <i class="bi bi-pencil"></i>
+                                    </button>
+                                    <button class="btn btn-sm btn-outline-danger" @onclick="() => DeleteSchedule(s.Id)">
+                                        <i class="bi bi-trash"></i>
+                                    </button>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </div>
+</div>
+
+@if (showModal)
+{
+    <div class="modal fade show d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5)">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content shadow-lg border-0">
+                <div class="modal-header">
+                    <h5 class="modal-title">@(editingId.HasValue ? "Edit Schedule" : "New Schedule")</h5>
+                    <button type="button" class="btn-close" @onclick="CloseModal"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="row mb-3">
+                        <div class="col-md-8">
+                            <label class="form-label">Schedule Name</label>
+                            <input class="form-control" @bind="model.Name" placeholder="e.g. Morning Lobby Loop" />
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label">Priority</label>
+                            <input type="number" class="form-control" @bind="model.Priority" />
+                            <small class="text-muted">Higher number wins on overlap</small>
+                        </div>
+                    </div>
+
+                    <div class="row mb-3">
+                        <div class="col-md-12">
+                            <label class="form-label d-block">Target Device Groups</label>
+                            <div class="dropdown" style="position: relative;">
+                                <button class="group-dropdown-btn dropdown-toggle w-100 d-flex justify-content-between align-items-center rounded" 
+                                        type="button" @onclick="ToggleGroupDropdown">
+                                    <span>
+                                        @if (model.TargetGroups.Count == 0)
+                                        {
+                                            <span class="text-muted">All Groups (Global)</span>
+                                        }
+                                        else
+                                        {
+                                            @foreach (var gName in model.TargetGroups)
+                                            {
+                                                <span class="badge bg-primary me-1">@gName</span>
+                                            }
+                                        }
+                                    </span>
+                                </button>
+                                <div class="group-dropdown-menu w-100 shadow @(showGroupDropdown ? "show" : "")" 
+                                     style="position: absolute; top: 100%; left: 0; z-index: 1000; display: @(showGroupDropdown ? "block" : "none");"
+                                     @onclick:stopPropagation="true">
+                                    <button class="group-item-btn" type="button" @onclick="() => { model.TargetGroups.Clear(); showGroupDropdown = false; }">
+                                        <i class="bi @(model.TargetGroups.Count == 0 ? "bi-check-circle-fill text-primary" : "bi-circle") me-2"></i>
+                                        <strong>All Groups (Global)</strong>
+                                    </button>
+                                    <hr class="dropdown-divider my-1">
+                                    @if (groups == null)
+                                    {
+                                        <div class="px-3 py-2 text-muted small"><span class="spinner-border spinner-border-sm me-1"></span> Loading groups...</div>
+                                    }
+                                    else if (groups.Count == 0)
+                                    {
+                                        <div class="px-3 py-2 text-muted small">No groups found. Manage them in <a href="versions" @onclick="CloseModal">Versions</a>.</div>
+                                    }
+                                    else
+                                    {
+                                        @foreach (var g in groups)
+                                        {
+                                            <button class="group-item-btn" type="button" @onclick="() => ToggleGroup(g.GroupName)">
+                                                <i class="bi @(model.TargetGroups.Contains(g.GroupName) ? "bi-check-square-fill text-primary" : "bi-square") me-2"></i>
+                                                @g.GroupName
+                                            </button>
+                                        }
+                                    }
+                                </div>
+                            </div>
+                            <small class="text-muted">Choose specific groups or leave as "Global" to target all devices.</small>
+                        </div>
+                    </div>
+
+                    <div class="row mb-3">
+                        <div class="col-md-6">
+                            <label class="form-label">Playlist</label>
+                            <select class="form-select" @bind="model.PlaylistId">
+                                <option value="0">Select a playlist...</option>
+                                @if (playlists != null)
+                                {
+                                    @foreach (var p in playlists)
+                                    {
+                                        <option value="@p.Id">@p.Name</option>
+                                    }
+                                }
+                            </select>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label d-block">Recurrence</label>
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="radio" name="scheduleType" id="typeRecurring" 
+                                       checked="@(!model.UseSpecificDate)" @onchange="() => model.UseSpecificDate = false">
+                                <label class="form-check-label" for="typeRecurring">Recurring Days</label>
+                            </div>
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="radio" name="scheduleType" id="typeOneTime" 
+                                       checked="@(model.UseSpecificDate)" @onchange="() => model.UseSpecificDate = true">
+                                <label class="form-check-label" for="typeOneTime">One-time</label>
+                            </div>
+                        </div>
+                    </div>
+
+                    @if (model.UseSpecificDate)
+                    {
+                        <div class="mb-3">
+                            <label class="form-label">Scheduled Date</label>
+                            <input type="date" class="form-control" 
+                                   value="@model.ScheduledDate?.ToString("yyyy-MM-dd")" 
+                                   @onchange="e => { if (DateOnly.TryParse(e.Value?.ToString(), out var d)) model.ScheduledDate = d; }" />
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="mb-3">
+                            <label class="form-label d-block">Days of Week</label>
+                            <div class="btn-group w-100" role="group">
+                                @foreach (DayOfWeekFlags day in Enum.GetValues<DayOfWeekFlags>())
+                                {
+                                    if (day == DayOfWeekFlags.None || day == DayOfWeekFlags.All) continue;
+                                    
+                                    <input type="checkbox" class="btn-check" id="btncheck-@day" autocomplete="off"
+                                           checked="@((model.DaysOfWeek & day) != 0)"
+                                           @onchange="() => ToggleDay(day)">
+                                    <label class="btn btn-outline-primary" for="btncheck-@day">@day.ToString().Substring(0, 3)</label>
+                                }
+                            </div>
+                        </div>
+                    }
+
+                    <div class="row mb-3">
+                        <div class="col-md-6">
+                            <label class="form-label">Start Time</label>
+                            <input type="time" class="form-control" 
+                                   value="@model.StartTime.ToString("HH:mm")" 
+                                   @onchange="e => { if (TimeOnly.TryParse(e.Value?.ToString(), out var t)) model.StartTime = t; }" />
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label">End Time</label>
+                            <input type="time" class="form-control" 
+                                   value="@model.EndTime.ToString("HH:mm")" 
+                                   @onchange="e => { if (TimeOnly.TryParse(e.Value?.ToString(), out var t)) model.EndTime = t; }" />
+                        </div>
+                    </div>
+
+                    <div class="form-check form-switch mt-4">
+                        <input class="form-check-input" type="checkbox" id="isActiveSwitch" @bind="model.IsActive">
+                        <label class="form-check-label" for="isActiveSwitch">Schedule is active</label>
+                    </div>
+                </div>
+                <div class="modal-footer bg-light">
+                    <button type="button" class="btn btn-secondary" @onclick="CloseModal">Cancel</button>
+                    <button type="button" class="btn btn-primary" @onclick="SaveSchedule" 
+                            disabled="@(!IsValid() || saving)">
+                        @if (saving)
+                        {
+                            <span class="spinner-border spinner-border-sm me-1"></span>
+                        }
+                        <i class="bi bi-check-lg me-1"></i> Save Schedule
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private List<Schedule>? schedules;
+    private List<Playlist>? playlists;
+    private List<DeviceGroupVersion>? groups;
+    private HttpClient? httpClient;
+    private string? loadError;
+
+    private bool showModal;
+    private bool showGroupDropdown;
+    private int? editingId;
+    private bool saving;
+    private ScheduleModel model = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        httpClient = HttpClientFactory.CreateClient();
+        httpClient.BaseAddress = new Uri(Navigation.BaseUri);
+        await LoadData();
+    }
+
+    private async Task LoadData()
+    {
+        loadError = null;
+        try
+        {
+            schedules = await httpClient!.GetFromJsonAsync<List<Schedule>>("/api/schedules");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading schedules");
+            loadError = "Failed to load schedules.";
+        }
+
+        try
+        {
+            playlists = await httpClient!.GetFromJsonAsync<List<Playlist>>("/api/playlists");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading playlists");
+            if (loadError == null) loadError = "Failed to load playlists.";
+        }
+
+        try
+        {
+            groups = await httpClient!.GetFromJsonAsync<List<DeviceGroupVersion>>("/api/versions/groups");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading groups");
+            if (loadError == null) loadError = "Failed to load device groups.";
+        }
+    }
+
+    private void ShowCreateSchedule()
+    {
+        editingId = null;
+        model = new ScheduleModel();
+        showModal = true;
+    }
+
+    private void EditSchedule(Schedule s)
+    {
+        editingId = s.Id;
+        model = new ScheduleModel
+        {
+            Name = s.Name,
+            PlaylistId = s.PlaylistId,
+            TargetGroups = s.TargetGroups?.Select(tg => tg.GroupName).ToList() ?? new List<string>(),
+            DaysOfWeek = s.DaysOfWeek,
+            ScheduledDate = s.ScheduledDate,
+            UseSpecificDate = s.ScheduledDate.HasValue,
+            StartTime = s.StartTime,
+            EndTime = s.EndTime,
+            Priority = s.Priority,
+            IsActive = s.IsActive
+        };
+        showModal = true;
+    }
+
+    private void CloseModal()
+    {
+        showModal = false;
+        showGroupDropdown = false;
+    }
+
+    private void ToggleGroupDropdown()
+    {
+        showGroupDropdown = !showGroupDropdown;
+    }
+
+    private void ToggleDay(DayOfWeekFlags day)
+    {
+        if ((model.DaysOfWeek & day) != 0)
+            model.DaysOfWeek &= ~day;
+        else
+            model.DaysOfWeek |= day;
+    }
+
+    private void ToggleGroup(string groupName)
+    {
+        if (model.TargetGroups.Contains(groupName))
+            model.TargetGroups.Remove(groupName);
+        else
+            model.TargetGroups.Add(groupName);
+    }
+
+    private bool IsValid()
+    {
+        if (string.IsNullOrWhiteSpace(model.Name) || model.PlaylistId == 0)
+            return false;
+
+        if (model.UseSpecificDate)
+            return model.ScheduledDate.HasValue;
+        
+        return model.DaysOfWeek != DayOfWeekFlags.None;
+    }
+
+    private async Task SaveSchedule()
+    {
+        if (!IsValid()) return;
+
+        saving = true;
+        try
+        {
+            // Clear specific fields based on type before sending
+            var payload = new 
+            {
+                model.Name,
+                model.PlaylistId,
+                model.TargetGroups,
+                DaysOfWeek = model.UseSpecificDate ? DayOfWeekFlags.None : model.DaysOfWeek,
+                ScheduledDate = model.UseSpecificDate ? model.ScheduledDate : null,
+                model.StartTime,
+                model.EndTime,
+                model.Priority,
+                model.IsActive
+            };
+
+            HttpResponseMessage response;
+            if (editingId.HasValue)
+                response = await httpClient!.PutAsJsonAsync($"/api/schedules/{editingId}", payload);
+            else
+                response = await httpClient!.PostAsJsonAsync("/api/schedules", payload);
+
+            if (response.IsSuccessStatusCode)
+            {
+                showModal = false;
+                await LoadData();
+            }
+            else
+            {
+                string body = await response.Content.ReadAsStringAsync();
+                loadError = $"Failed to save schedule: {body}";
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error saving schedule");
+            loadError = "Error saving schedule.";
+        }
+        finally
+        {
+            saving = false;
+        }
+    }
+
+    private async Task DeleteSchedule(int id)
+    {
+        bool confirmed = await JS.InvokeAsync<bool>("confirm", "Are you sure you want to delete this schedule?");
+        if (!confirmed) return;
+
+        try
+        {
+            var response = await httpClient!.DeleteAsync($"/api/schedules/{id}");
+            if (response.IsSuccessStatusCode)
+                await LoadData();
+            else
+                loadError = "Failed to delete schedule.";
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error deleting schedule {Id}", id);
+            loadError = "Failed to delete schedule.";
+        }
+    }
+
+    private List<string> GetActiveDays(DayOfWeekFlags flags)
+    {
+        if (flags == DayOfWeekFlags.All) return new List<string> { "Daily" };
+        
+        var days = new List<string>();
+        foreach (DayOfWeekFlags day in Enum.GetValues<DayOfWeekFlags>())
+        {
+            if (day == DayOfWeekFlags.None || day == DayOfWeekFlags.All) continue;
+            if ((flags & day) != 0)
+                days.Add(day.ToString().Substring(0, 3));
+        }
+        return days;
+    }
+
+    public void Dispose()
+    {
+        httpClient?.Dispose();
+    }
+
+    private class ScheduleModel
+    {
+        public string Name { get; set; } = "";
+        public int PlaylistId { get; set; }
+        public List<string> TargetGroups { get; set; } = new();
+        public bool UseSpecificDate { get; set; }
+        public DayOfWeekFlags DaysOfWeek { get; set; } = DayOfWeekFlags.All;
+        public DateOnly? ScheduledDate { get; set; } = DateOnly.FromDateTime(DateTime.Today);
+        public TimeOnly StartTime { get; set; } = new TimeOnly(0, 0);
+        public TimeOnly EndTime { get; set; } = new TimeOnly(23, 59);
+        public int Priority { get; set; } = 1;
+        public bool IsActive { get; set; } = true;
+    }
+}

--- a/src/PlainSight.Server/Components/Pages/Schedules.razor
+++ b/src/PlainSight.Server/Components/Pages/Schedules.razor
@@ -6,6 +6,7 @@
 @inject IJSRuntime JS
 @inject ILogger<Schedules> Logger
 @using PlainSight.Shared.Models
+@using PlainSight.Server.Api
 @implements IDisposable
 
 <PageTitle>Schedules — PlainSight</PageTitle>
@@ -58,7 +59,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var s in schedules)
+                        @foreach (Schedule s in schedules)
                         {
                             <tr>
                                 <td><strong>@s.Name</strong></td>
@@ -70,7 +71,7 @@
                                     else
                                     {
                                         <div class="d-flex gap-1 flex-wrap" style="max-width: 250px;">
-                                            @foreach (var tg in s.TargetGroups)
+                                            @foreach (ScheduleTargetGroup tg in s.TargetGroups)
                                             {
                                                 <span class="badge bg-info text-dark">@tg.GroupName</span>
                                             }
@@ -88,7 +89,7 @@
                                     else
                                     {
                                         <div class="d-flex gap-1 flex-wrap" style="max-width: 200px;">
-                                            @foreach (var day in GetActiveDays(s.DaysOfWeek))
+                                            @foreach (string day in GetActiveDays(s.DaysOfWeek))
                                             {
                                                 <span class="badge bg-light text-dark border">@day</span>
                                             }
@@ -161,7 +162,7 @@
                                         }
                                         else
                                         {
-                                            @foreach (var gName in model.TargetGroups)
+                                            @foreach (string gName in model.TargetGroups)
                                             {
                                                 <span class="badge bg-primary me-1">@gName</span>
                                             }
@@ -186,7 +187,7 @@
                                     }
                                     else
                                     {
-                                        @foreach (var g in groups)
+                                        @foreach (DeviceGroupVersion g in groups)
                                         {
                                             <button class="group-item-btn" type="button" @onclick="() => ToggleGroup(g.GroupName)">
                                                 <i class="bi @(model.TargetGroups.Contains(g.GroupName) ? "bi-check-square-fill text-primary" : "bi-square") me-2"></i>
@@ -207,7 +208,7 @@
                                 <option value="0">Select a playlist...</option>
                                 @if (playlists != null)
                                 {
-                                    @foreach (var p in playlists)
+                                    @foreach (Playlist p in playlists)
                                     {
                                         <option value="@p.Id">@p.Name</option>
                                     }
@@ -235,7 +236,7 @@
                             <label class="form-label">Scheduled Date</label>
                             <input type="date" class="form-control" 
                                    value="@model.ScheduledDate?.ToString("yyyy-MM-dd")" 
-                                   @onchange="e => { if (DateOnly.TryParse(e.Value?.ToString(), out var d)) model.ScheduledDate = d; }" />
+                                   @onchange="e => { if (DateOnly.TryParse(e.Value?.ToString(), out DateOnly d)) model.ScheduledDate = d; }" />
                         </div>
                     }
                     else
@@ -261,13 +262,13 @@
                             <label class="form-label">Start Time</label>
                             <input type="time" class="form-control" 
                                    value="@model.StartTime.ToString("HH:mm")" 
-                                   @onchange="e => { if (TimeOnly.TryParse(e.Value?.ToString(), out var t)) model.StartTime = t; }" />
+                                   @onchange="e => { if (TimeOnly.TryParse(e.Value?.ToString(), out TimeOnly t)) model.StartTime = t; }" />
                         </div>
                         <div class="col-md-6">
                             <label class="form-label">End Time</label>
                             <input type="time" class="form-control" 
                                    value="@model.EndTime.ToString("HH:mm")" 
-                                   @onchange="e => { if (TimeOnly.TryParse(e.Value?.ToString(), out var t)) model.EndTime = t; }" />
+                                   @onchange="e => { if (TimeOnly.TryParse(e.Value?.ToString(), out TimeOnly t)) model.EndTime = t; }" />
                         </div>
                     </div>
 
@@ -417,19 +418,16 @@
         saving = true;
         try
         {
-            // Clear specific fields based on type before sending
-            var payload = new 
-            {
+            ScheduleCreateDto payload = new(
                 model.Name,
                 model.PlaylistId,
                 model.TargetGroups,
-                DaysOfWeek = model.UseSpecificDate ? DayOfWeekFlags.None : model.DaysOfWeek,
-                ScheduledDate = model.UseSpecificDate ? model.ScheduledDate : null,
+                model.UseSpecificDate ? DayOfWeekFlags.None : model.DaysOfWeek,
+                model.UseSpecificDate ? model.ScheduledDate : null,
                 model.StartTime,
                 model.EndTime,
                 model.Priority,
-                model.IsActive
-            };
+                model.IsActive);
 
             HttpResponseMessage response;
             if (editingId.HasValue)
@@ -466,7 +464,7 @@
 
         try
         {
-            var response = await httpClient!.DeleteAsync($"/api/schedules/{id}");
+            HttpResponseMessage response = await httpClient!.DeleteAsync($"/api/schedules/{id}");
             if (response.IsSuccessStatusCode)
                 await LoadData();
             else
@@ -483,7 +481,7 @@
     {
         if (flags == DayOfWeekFlags.All) return new List<string> { "Daily" };
         
-        var days = new List<string>();
+        List<string> days = new();
         foreach (DayOfWeekFlags day in Enum.GetValues<DayOfWeekFlags>())
         {
             if (day == DayOfWeekFlags.None || day == DayOfWeekFlags.All) continue;
@@ -498,7 +496,7 @@
         httpClient?.Dispose();
     }
 
-    private class ScheduleModel
+    private sealed class ScheduleModel
     {
         public string Name { get; set; } = "";
         public int PlaylistId { get; set; }

--- a/src/PlainSight.Server/Components/Pages/Schedules.razor.css
+++ b/src/PlainSight.Server/Components/Pages/Schedules.razor.css
@@ -1,0 +1,43 @@
+.group-dropdown-btn {
+    background-color: #ffffff !important;
+    border: 1px solid var(--ps-border) !important;
+    color: var(--ps-text) !important;
+    padding: 0.5rem 0.75rem !important;
+    transition: all 0.2s !important;
+}
+
+.group-dropdown-btn:hover {
+    background-color: #f8fafc !important;
+    border-color: var(--ps-accent) !important;
+    color: var(--ps-text) !important;
+}
+
+.group-dropdown-menu {
+    max-height: 300px !important;
+    overflow-y: auto !important;
+    padding: 0.5rem 0 !important;
+    background-color: #ffffff !important;
+    border: 1px solid var(--ps-border) !important;
+    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1) !important;
+}
+
+.group-item-btn {
+    width: 100% !important;
+    text-align: left !important;
+    background: none !important;
+    border: none !important;
+    padding: 0.625rem 1rem !important;
+    color: var(--ps-text) !important;
+    display: flex !important;
+    align-items: center !important;
+    font-size: 0.875rem !important;
+}
+
+.group-item-btn:hover {
+    background-color: var(--ps-accent-light) !important;
+    color: var(--ps-accent-dark) !important;
+}
+
+.group-item-btn i {
+    font-size: 1.1rem !important;
+}

--- a/src/PlainSight.Server/Components/Pages/Versions.razor
+++ b/src/PlainSight.Server/Components/Pages/Versions.razor
@@ -418,7 +418,7 @@
         if (bytes >= 1024 * 1024)
             return $"{bytes / 1024.0 / 1024.0:F1} MB";
         if (bytes >= 1024)
-            return $"{bytes / 1024.0 / 1024.0:F1} KB";
+            return $"{bytes / 1024.0:F1} KB";
         return $"{bytes} B";
     }
 

--- a/src/PlainSight.Server/Components/Pages/Versions.razor
+++ b/src/PlainSight.Server/Components/Pages/Versions.razor
@@ -149,15 +149,35 @@
                                     </button>
                                 </div>
                                 <div class="mt-1">
+                                    <label class="small text-muted mb-0">Target Version</label>
                                     <select class="form-select form-select-sm"
                                             value="@g.TargetVersion"
-                                            @onchange="e => SaveGroupVersion(g.GroupName, e.Value?.ToString() ?? g.TargetVersion)"
-                                            disabled="@(versions == null || versions.Count == 0)">
+                                            @onchange="e => SaveGroupVersion(g.GroupName, e.Value?.ToString() ?? g.TargetVersion, g.DefaultPlaylistId)"
+                                            disabled="@(versions == null)">
                                         @if (versions != null)
                                         {
+                                            @if (!versions.Any(v => v.VersionNumber == g.TargetVersion))
+                                            {
+                                                <option value="@g.TargetVersion">@g.TargetVersion (Missing)</option>
+                                            }
                                             @foreach (PlayerVersion v in versions)
                                             {
                                                 <option value="@v.VersionNumber">@v.VersionNumber</option>
+                                            }
+                                        }
+                                    </select>
+                                </div>
+                                <div class="mt-1">
+                                    <label class="small text-muted mb-0">Default Playlist</label>
+                                    <select class="form-select form-select-sm"
+                                            value="@g.DefaultPlaylistId"
+                                            @onchange="e => SaveGroupVersion(g.GroupName, g.TargetVersion, int.TryParse(e.Value?.ToString(), out int id) ? id : null)">
+                                        <option value="">(None)</option>
+                                        @if (playlists != null)
+                                        {
+                                            @foreach (Playlist p in playlists)
+                                            {
+                                                <option value="@p.Id">@p.Name</option>
                                             }
                                         }
                                     </select>
@@ -170,7 +190,7 @@
                         <input class="form-control" placeholder="New group name" @bind="newGroupName" />
                         <button class="btn btn-outline-primary"
                                 @onclick="AddGroup"
-                                disabled="@(string.IsNullOrWhiteSpace(newGroupName) || versions == null || versions.Count == 0)">
+                                disabled="@(string.IsNullOrWhiteSpace(newGroupName) || versions == null)">
                             <i class="bi bi-plus-circle"></i> Add
                         </button>
                     </div>
@@ -203,6 +223,7 @@
 @code {
     private List<PlayerVersion>? versions;
     private List<DeviceGroupVersion>? groups;
+    private List<Playlist>? playlists;
     private HttpClient? httpClient;
 
     private string uploadVersion = string.Empty;
@@ -229,6 +250,7 @@
         {
             versions = await httpClient!.GetFromJsonAsync<List<PlayerVersion>>("/api/versions");
             groups = await httpClient!.GetFromJsonAsync<List<DeviceGroupVersion>>("/api/versions/groups");
+            playlists = await httpClient!.GetFromJsonAsync<List<Playlist>>("/api/playlists");
             loadError = null;
         }
         catch (Exception ex)
@@ -310,13 +332,13 @@
         }
     }
 
-    private async Task SaveGroupVersion(string groupName, string targetVersion)
+    private async Task SaveGroupVersion(string groupName, string targetVersion, int? defaultPlaylistId)
     {
         try
         {
             HttpResponseMessage response = await httpClient!.PutAsJsonAsync(
                 $"/api/versions/groups/{Uri.EscapeDataString(groupName)}",
-                new { TargetVersion = targetVersion });
+                new { TargetVersion = targetVersion, DefaultPlaylistId = defaultPlaylistId });
 
             if (!response.IsSuccessStatusCode)
             {
@@ -337,18 +359,19 @@
 
     private async Task AddGroup()
     {
-        if (string.IsNullOrWhiteSpace(newGroupName) || versions == null || versions.Count == 0) return;
+        if (string.IsNullOrWhiteSpace(newGroupName)) return;
 
-        // Default to the version assigned to the 'Default' group, or fallback to the first version
+        // Default to the version assigned to the 'Default' group, or fallback to the first version or 1.0.0
         string defaultVersion = groups?.FirstOrDefault(g => g.GroupName == "Default")?.TargetVersion 
-                               ?? versions[0].VersionNumber;
+                               ?? (versions?.Count > 0 ? versions[0].VersionNumber : "1.0.0");
+        int? defaultPlaylistId = groups?.FirstOrDefault(g => g.GroupName == "Default")?.DefaultPlaylistId;
         groupError = null;
 
         try
         {
             HttpResponseMessage response = await httpClient!.PutAsJsonAsync(
                 $"/api/versions/groups/{Uri.EscapeDataString(newGroupName.Trim())}",
-                new { TargetVersion = defaultVersion });
+                new { TargetVersion = defaultVersion, DefaultPlaylistId = defaultPlaylistId });
 
             if (response.IsSuccessStatusCode)
             {
@@ -395,7 +418,7 @@
         if (bytes >= 1024 * 1024)
             return $"{bytes / 1024.0 / 1024.0:F1} MB";
         if (bytes >= 1024)
-            return $"{bytes / 1024.0:F1} KB";
+            return $"{bytes / 1024.0 / 1024.0:F1} KB";
         return $"{bytes} B";
     }
 

--- a/src/PlainSight.Server/Data/PlainSightDbContext.cs
+++ b/src/PlainSight.Server/Data/PlainSightDbContext.cs
@@ -9,6 +9,7 @@ public class PlainSightDbContext(DbContextOptions<PlainSightDbContext> options) 
     public DbSet<ContentItem> ContentItems => this.Set<ContentItem>();
     public DbSet<Playlist> Playlists => this.Set<Playlist>();
     public DbSet<PlaylistItem> PlaylistItems => this.Set<PlaylistItem>();
+    public DbSet<Schedule> Schedules => this.Set<Schedule>();
     public DbSet<PlayerVersion> PlayerVersions => this.Set<PlayerVersion>();
     public DbSet<DeviceGroupVersion> DeviceGroupVersions => this.Set<DeviceGroupVersion>();
     public DbSet<AdminUser> AdminUsers => this.Set<AdminUser>();
@@ -38,6 +39,25 @@ public class PlainSightDbContext(DbContextOptions<PlainSightDbContext> options) 
                 .OnDelete(DeleteBehavior.Cascade);
         });
 
+        modelBuilder.Entity<Schedule>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasOne(e => e.Playlist)
+                .WithMany()
+                .HasForeignKey(e => e.PlaylistId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<ScheduleTargetGroup>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasOne(e => e.Schedule)
+                .WithMany(s => s.TargetGroups)
+                .HasForeignKey(e => e.ScheduleId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasIndex(e => new { e.ScheduleId, e.GroupName }).IsUnique();
+        });
+
         modelBuilder.Entity<PlaylistItem>(entity =>
         {
             entity.HasKey(e => e.Id);
@@ -57,6 +77,11 @@ public class PlainSightDbContext(DbContextOptions<PlainSightDbContext> options) 
         {
             entity.HasKey(e => e.Id);
             entity.HasIndex(e => e.GroupName).IsUnique();
+
+            entity.HasOne(e => e.DefaultPlaylist)
+                .WithMany()
+                .HasForeignKey(e => e.DefaultPlaylistId)
+                .OnDelete(DeleteBehavior.SetNull);
 
             // Seed Default group
             entity.HasData(new DeviceGroupVersion

--- a/src/PlainSight.Server/Migrations/20260430184208_AddSchedules.Designer.cs
+++ b/src/PlainSight.Server/Migrations/20260430184208_AddSchedules.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PlainSight.Server.Data;
@@ -11,9 +12,11 @@ using PlainSight.Server.Data;
 namespace PlainSight.Server.Migrations
 {
     [DbContext(typeof(PlainSightDbContext))]
-    partial class PlainSightDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430184208_AddSchedules")]
+    partial class AddSchedules
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -111,9 +114,6 @@ namespace PlainSight.Server.Migrations
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
-                    b.Property<string>("ApiKey")
-                        .HasColumnType("text");
-
                     b.Property<string>("CallbackUrl")
                         .HasColumnType("text");
 
@@ -164,9 +164,6 @@ namespace PlainSight.Server.Migrations
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
-                    b.Property<int?>("DefaultPlaylistId")
-                        .HasColumnType("integer");
-
                     b.Property<string>("GroupName")
                         .IsRequired()
                         .HasColumnType("text");
@@ -176,8 +173,6 @@ namespace PlainSight.Server.Migrations
                         .HasColumnType("text");
 
                     b.HasKey("Id");
-
-                    b.HasIndex("DefaultPlaylistId");
 
                     b.HasIndex("GroupName")
                         .IsUnique();
@@ -295,6 +290,9 @@ namespace PlainSight.Server.Migrations
                     b.Property<int>("DaysOfWeek")
                         .HasColumnType("integer");
 
+                    b.Property<string>("DeviceGroup")
+                        .HasColumnType("text");
+
                     b.Property<TimeOnly>("EndTime")
                         .HasColumnType("time without time zone");
 
@@ -311,9 +309,6 @@ namespace PlainSight.Server.Migrations
                     b.Property<int>("Priority")
                         .HasColumnType("integer");
 
-                    b.Property<DateOnly?>("ScheduledDate")
-                        .HasColumnType("date");
-
                     b.Property<TimeOnly>("StartTime")
                         .HasColumnType("time without time zone");
 
@@ -322,39 +317,6 @@ namespace PlainSight.Server.Migrations
                     b.HasIndex("PlaylistId");
 
                     b.ToTable("Schedules");
-                });
-
-            modelBuilder.Entity("PlainSight.Shared.Models.ScheduleTargetGroup", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("GroupName")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<int>("ScheduleId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ScheduleId", "GroupName")
-                        .IsUnique();
-
-                    b.ToTable("ScheduleTargetGroup");
-                });
-
-            modelBuilder.Entity("PlainSight.Shared.Models.DeviceGroupVersion", b =>
-                {
-                    b.HasOne("PlainSight.Shared.Models.Playlist", "DefaultPlaylist")
-                        .WithMany()
-                        .HasForeignKey("DefaultPlaylistId")
-                        .OnDelete(DeleteBehavior.SetNull);
-
-                    b.Navigation("DefaultPlaylist");
                 });
 
             modelBuilder.Entity("PlainSight.Shared.Models.PlaylistItem", b =>
@@ -387,25 +349,9 @@ namespace PlainSight.Server.Migrations
                     b.Navigation("Playlist");
                 });
 
-            modelBuilder.Entity("PlainSight.Shared.Models.ScheduleTargetGroup", b =>
-                {
-                    b.HasOne("PlainSight.Shared.Models.Schedule", "Schedule")
-                        .WithMany("TargetGroups")
-                        .HasForeignKey("ScheduleId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Schedule");
-                });
-
             modelBuilder.Entity("PlainSight.Shared.Models.Playlist", b =>
                 {
                     b.Navigation("Items");
-                });
-
-            modelBuilder.Entity("PlainSight.Shared.Models.Schedule", b =>
-                {
-                    b.Navigation("TargetGroups");
                 });
 #pragma warning restore 612, 618
         }

--- a/src/PlainSight.Server/Migrations/20260430184208_AddSchedules.cs
+++ b/src/PlainSight.Server/Migrations/20260430184208_AddSchedules.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace PlainSight.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSchedules : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Schedules",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "text", nullable: false),
+                    PlaylistId = table.Column<int>(type: "integer", nullable: false),
+                    DeviceGroup = table.Column<string>(type: "text", nullable: true),
+                    DaysOfWeek = table.Column<int>(type: "integer", nullable: false),
+                    StartTime = table.Column<TimeOnly>(type: "time without time zone", nullable: false),
+                    EndTime = table.Column<TimeOnly>(type: "time without time zone", nullable: false),
+                    Priority = table.Column<int>(type: "integer", nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Schedules", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Schedules_Playlists_PlaylistId",
+                        column: x => x.PlaylistId,
+                        principalTable: "Playlists",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Schedules_PlaylistId",
+                table: "Schedules",
+                column: "PlaylistId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Schedules");
+        }
+    }
+}

--- a/src/PlainSight.Server/Migrations/20260430184307_AddGroupDefaultPlaylist.Designer.cs
+++ b/src/PlainSight.Server/Migrations/20260430184307_AddGroupDefaultPlaylist.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PlainSight.Server.Data;
@@ -11,9 +12,11 @@ using PlainSight.Server.Data;
 namespace PlainSight.Server.Migrations
 {
     [DbContext(typeof(PlainSightDbContext))]
-    partial class PlainSightDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430184307_AddGroupDefaultPlaylist")]
+    partial class AddGroupDefaultPlaylist
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -110,9 +113,6 @@ namespace PlainSight.Server.Migrations
                         .HasColumnType("integer");
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("ApiKey")
-                        .HasColumnType("text");
 
                     b.Property<string>("CallbackUrl")
                         .HasColumnType("text");
@@ -295,6 +295,9 @@ namespace PlainSight.Server.Migrations
                     b.Property<int>("DaysOfWeek")
                         .HasColumnType("integer");
 
+                    b.Property<string>("DeviceGroup")
+                        .HasColumnType("text");
+
                     b.Property<TimeOnly>("EndTime")
                         .HasColumnType("time without time zone");
 
@@ -311,9 +314,6 @@ namespace PlainSight.Server.Migrations
                     b.Property<int>("Priority")
                         .HasColumnType("integer");
 
-                    b.Property<DateOnly?>("ScheduledDate")
-                        .HasColumnType("date");
-
                     b.Property<TimeOnly>("StartTime")
                         .HasColumnType("time without time zone");
 
@@ -322,29 +322,6 @@ namespace PlainSight.Server.Migrations
                     b.HasIndex("PlaylistId");
 
                     b.ToTable("Schedules");
-                });
-
-            modelBuilder.Entity("PlainSight.Shared.Models.ScheduleTargetGroup", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("GroupName")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<int>("ScheduleId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ScheduleId", "GroupName")
-                        .IsUnique();
-
-                    b.ToTable("ScheduleTargetGroup");
                 });
 
             modelBuilder.Entity("PlainSight.Shared.Models.DeviceGroupVersion", b =>
@@ -387,25 +364,9 @@ namespace PlainSight.Server.Migrations
                     b.Navigation("Playlist");
                 });
 
-            modelBuilder.Entity("PlainSight.Shared.Models.ScheduleTargetGroup", b =>
-                {
-                    b.HasOne("PlainSight.Shared.Models.Schedule", "Schedule")
-                        .WithMany("TargetGroups")
-                        .HasForeignKey("ScheduleId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Schedule");
-                });
-
             modelBuilder.Entity("PlainSight.Shared.Models.Playlist", b =>
                 {
                     b.Navigation("Items");
-                });
-
-            modelBuilder.Entity("PlainSight.Shared.Models.Schedule", b =>
-                {
-                    b.Navigation("TargetGroups");
                 });
 #pragma warning restore 612, 618
         }

--- a/src/PlainSight.Server/Migrations/20260430184307_AddGroupDefaultPlaylist.cs
+++ b/src/PlainSight.Server/Migrations/20260430184307_AddGroupDefaultPlaylist.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PlainSight.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGroupDefaultPlaylist : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "DefaultPlaylistId",
+                table: "DeviceGroupVersions",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.UpdateData(
+                table: "DeviceGroupVersions",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "DefaultPlaylistId",
+                value: null);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DeviceGroupVersions_DefaultPlaylistId",
+                table: "DeviceGroupVersions",
+                column: "DefaultPlaylistId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DeviceGroupVersions_Playlists_DefaultPlaylistId",
+                table: "DeviceGroupVersions",
+                column: "DefaultPlaylistId",
+                principalTable: "Playlists",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_DeviceGroupVersions_Playlists_DefaultPlaylistId",
+                table: "DeviceGroupVersions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DeviceGroupVersions_DefaultPlaylistId",
+                table: "DeviceGroupVersions");
+
+            migrationBuilder.DropColumn(
+                name: "DefaultPlaylistId",
+                table: "DeviceGroupVersions");
+        }
+    }
+}

--- a/src/PlainSight.Server/Migrations/20260430190937_AddScheduleDate.Designer.cs
+++ b/src/PlainSight.Server/Migrations/20260430190937_AddScheduleDate.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PlainSight.Server.Data;
@@ -11,9 +12,11 @@ using PlainSight.Server.Data;
 namespace PlainSight.Server.Migrations
 {
     [DbContext(typeof(PlainSightDbContext))]
-    partial class PlainSightDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430190937_AddScheduleDate")]
+    partial class AddScheduleDate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -295,6 +298,9 @@ namespace PlainSight.Server.Migrations
                     b.Property<int>("DaysOfWeek")
                         .HasColumnType("integer");
 
+                    b.Property<string>("DeviceGroup")
+                        .HasColumnType("text");
+
                     b.Property<TimeOnly>("EndTime")
                         .HasColumnType("time without time zone");
 
@@ -322,29 +328,6 @@ namespace PlainSight.Server.Migrations
                     b.HasIndex("PlaylistId");
 
                     b.ToTable("Schedules");
-                });
-
-            modelBuilder.Entity("PlainSight.Shared.Models.ScheduleTargetGroup", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("GroupName")
-                        .IsRequired()
-                        .HasColumnType("text");
-
-                    b.Property<int>("ScheduleId")
-                        .HasColumnType("integer");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ScheduleId", "GroupName")
-                        .IsUnique();
-
-                    b.ToTable("ScheduleTargetGroup");
                 });
 
             modelBuilder.Entity("PlainSight.Shared.Models.DeviceGroupVersion", b =>
@@ -387,25 +370,9 @@ namespace PlainSight.Server.Migrations
                     b.Navigation("Playlist");
                 });
 
-            modelBuilder.Entity("PlainSight.Shared.Models.ScheduleTargetGroup", b =>
-                {
-                    b.HasOne("PlainSight.Shared.Models.Schedule", "Schedule")
-                        .WithMany("TargetGroups")
-                        .HasForeignKey("ScheduleId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Schedule");
-                });
-
             modelBuilder.Entity("PlainSight.Shared.Models.Playlist", b =>
                 {
                     b.Navigation("Items");
-                });
-
-            modelBuilder.Entity("PlainSight.Shared.Models.Schedule", b =>
-                {
-                    b.Navigation("TargetGroups");
                 });
 #pragma warning restore 612, 618
         }

--- a/src/PlainSight.Server/Migrations/20260430190937_AddScheduleDate.cs
+++ b/src/PlainSight.Server/Migrations/20260430190937_AddScheduleDate.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PlainSight.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddScheduleDate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "ScheduledDate",
+                table: "Schedules",
+                type: "date",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ScheduledDate",
+                table: "Schedules");
+        }
+    }
+}

--- a/src/PlainSight.Server/Migrations/20260430200431_MultiGroupSchedules.Designer.cs
+++ b/src/PlainSight.Server/Migrations/20260430200431_MultiGroupSchedules.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PlainSight.Server.Data;
@@ -11,9 +12,11 @@ using PlainSight.Server.Data;
 namespace PlainSight.Server.Migrations
 {
     [DbContext(typeof(PlainSightDbContext))]
-    partial class PlainSightDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430200431_MultiGroupSchedules")]
+    partial class MultiGroupSchedules
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PlainSight.Server/Migrations/20260430200431_MultiGroupSchedules.cs
+++ b/src/PlainSight.Server/Migrations/20260430200431_MultiGroupSchedules.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace PlainSight.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class MultiGroupSchedules : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeviceGroup",
+                table: "Schedules");
+
+            migrationBuilder.CreateTable(
+                name: "ScheduleTargetGroup",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ScheduleId = table.Column<int>(type: "integer", nullable: false),
+                    GroupName = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScheduleTargetGroup", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ScheduleTargetGroup_Schedules_ScheduleId",
+                        column: x => x.ScheduleId,
+                        principalTable: "Schedules",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScheduleTargetGroup_ScheduleId_GroupName",
+                table: "ScheduleTargetGroup",
+                columns: new[] { "ScheduleId", "GroupName" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ScheduleTargetGroup");
+
+            migrationBuilder.AddColumn<string>(
+                name: "DeviceGroup",
+                table: "Schedules",
+                type: "text",
+                nullable: true);
+        }
+    }
+}

--- a/src/PlainSight.Server/PlainSight.Server.csproj
+++ b/src/PlainSight.Server/PlainSight.Server.csproj
@@ -9,6 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/PlainSight.Server/Program.cs
+++ b/src/PlainSight.Server/Program.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.EntityFrameworkCore;
@@ -43,6 +44,12 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
 builder.Services.AddAuthorization();
 builder.Services.AddCascadingAuthenticationState();
 
+// Configure JSON options for Minimal APIs to handle object cycles
+builder.Services.Configure<Microsoft.AspNetCore.Http.Json.JsonOptions>(options =>
+{
+    options.SerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
+});
+
 // Add custom services
 builder.Services.AddSingleton<WebsiteRecorder>();
 builder.Services.AddSingleton<RenderQueue>();
@@ -50,6 +57,7 @@ builder.Services.AddHostedService<RenderWorkerService>();
 builder.Services.AddScoped<ContentSyncService>();
 builder.Services.AddHostedService<ContentSyncWorkerService>();
 builder.Services.AddScoped<VersionService>();
+builder.Services.AddScoped<ScheduleService>();
 
 // Add HttpClient for calling our own API and the players
 builder.Services.AddHttpClient();
@@ -136,6 +144,7 @@ app.MapDefaultEndpoints();
 app.MapContentApi();
 app.MapDeviceApi();
 app.MapPlaylistApi();
+app.MapScheduleApi();
 app.MapUpdateApi();
 app.MapVersionApi();
 

--- a/src/PlainSight.Server/Services/ScheduleService.cs
+++ b/src/PlainSight.Server/Services/ScheduleService.cs
@@ -1,0 +1,79 @@
+using Microsoft.EntityFrameworkCore;
+using PlainSight.Server.Data;
+using PlainSight.Shared.Models;
+
+namespace PlainSight.Server.Services;
+
+public class ScheduleService(PlainSightDbContext dbContext)
+{
+    public async Task<Playlist?> GetActivePlaylistAsync(string deviceGroup, DateTime utcNow)
+    {
+        DateOnly currentDate = DateOnly.FromDateTime(utcNow);
+        TimeOnly currentTime = TimeOnly.FromDateTime(utcNow);
+        DayOfWeek currentDay = utcNow.DayOfWeek;
+        DayOfWeekFlags dayFlag = GetDayOfWeekFlag(currentDay);
+
+        // 1. Check for active schedules matching group and current day/time
+        // Matches if: (TargetGroups is empty [Global] OR TargetGroups contains deviceGroup)
+        // AND ((ScheduledDate matches today) OR (ScheduledDate is null AND DaysOfWeek matches today))
+        Playlist? scheduledPlaylist = await dbContext.Schedules
+            .Include(s => s.TargetGroups)
+            .Include(s => s.Playlist)
+            .ThenInclude(p => p.Items)
+            .ThenInclude(i => i.ContentItem)
+            .Where(s => s.IsActive &&
+                        (!s.TargetGroups.Any() || s.TargetGroups.Any(tg => tg.GroupName == deviceGroup)) &&
+                        ((s.ScheduledDate == currentDate) || (s.ScheduledDate == null && (s.DaysOfWeek & dayFlag) != 0)) &&
+                        s.StartTime <= currentTime &&
+                        s.EndTime >= currentTime)
+            .OrderByDescending(s => s.Priority)
+            .Select(s => s.Playlist)
+            .FirstOrDefaultAsync();
+
+        if (scheduledPlaylist != null)
+        {
+            return scheduledPlaylist;
+        }
+
+        // 2. Fallback to the group's default playlist
+        DeviceGroupVersion? groupConfig = await dbContext.DeviceGroupVersions
+            .Include(g => g.DefaultPlaylist!)
+            .ThenInclude(p => p.Items)
+            .ThenInclude(i => i.ContentItem)
+            .FirstOrDefaultAsync(g => g.GroupName == deviceGroup);
+
+        if (groupConfig?.DefaultPlaylist != null)
+        {
+            return groupConfig.DefaultPlaylist;
+        }
+
+        // 3. Last resort fallback: "Default" group's playlist if current group isn't "Default"
+        if (deviceGroup != "Default")
+        {
+            DeviceGroupVersion? defaultConfig = await dbContext.DeviceGroupVersions
+                .Include(g => g.DefaultPlaylist!)
+                .ThenInclude(p => p.Items)
+                .ThenInclude(i => i.ContentItem)
+                .FirstOrDefaultAsync(g => g.GroupName == "Default");
+            
+            return defaultConfig?.DefaultPlaylist;
+        }
+
+        return null;
+    }
+
+    private static DayOfWeekFlags GetDayOfWeekFlag(DayOfWeek day)
+    {
+        return day switch
+        {
+            DayOfWeek.Sunday => DayOfWeekFlags.Sunday,
+            DayOfWeek.Monday => DayOfWeekFlags.Monday,
+            DayOfWeek.Tuesday => DayOfWeekFlags.Tuesday,
+            DayOfWeek.Wednesday => DayOfWeekFlags.Wednesday,
+            DayOfWeek.Thursday => DayOfWeekFlags.Thursday,
+            DayOfWeek.Friday => DayOfWeekFlags.Friday,
+            DayOfWeek.Saturday => DayOfWeekFlags.Saturday,
+            _ => DayOfWeekFlags.None
+        };
+    }
+}

--- a/src/PlainSight.Shared/Models/DeviceGroupVersion.cs
+++ b/src/PlainSight.Shared/Models/DeviceGroupVersion.cs
@@ -5,4 +5,8 @@ public class DeviceGroupVersion
     public int Id { get; set; }
     public string GroupName { get; set; } = string.Empty;
     public string TargetVersion { get; set; } = string.Empty;
+    public int? DefaultPlaylistId { get; set; }
+
+    // Navigation property
+    public Playlist? DefaultPlaylist { get; set; }
 }

--- a/src/PlainSight.Shared/Models/HeartbeatResponse.cs
+++ b/src/PlainSight.Shared/Models/HeartbeatResponse.cs
@@ -5,4 +5,5 @@ public class HeartbeatResponse
     public bool RequestScreenshot { get; set; }
     public string? UpdateUrl { get; set; }
     public string? AssignedApiKey { get; set; }
+    public List<string>? PlaylistFiles { get; set; } // ordered list of filenames to play
 }

--- a/src/PlainSight.Shared/Models/Playlist.cs
+++ b/src/PlainSight.Shared/Models/Playlist.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace PlainSight.Shared.Models;
 
 public class Playlist
@@ -22,6 +24,7 @@ public class PlaylistItem
     public int? OverrideDurationSeconds { get; set; } // Optional override for this playlist
     
     // Navigation properties
+    [JsonIgnore]
     public Playlist Playlist { get; set; } = null!;
     public ContentItem ContentItem { get; set; } = null!;
 }

--- a/src/PlainSight.Shared/Models/Schedule.cs
+++ b/src/PlainSight.Shared/Models/Schedule.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace PlainSight.Shared.Models;
+
+[Flags]
+public enum DayOfWeekFlags
+{
+    None = 0,
+    Sunday = 1,
+    Monday = 2,
+    Tuesday = 4,
+    Wednesday = 8,
+    Thursday = 16,
+    Friday = 32,
+    Saturday = 64,
+    All = 127
+}
+
+public class Schedule
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int PlaylistId { get; set; }
+    
+    // If empty, this applies to ALL groups
+    public ICollection<ScheduleTargetGroup> TargetGroups { get; set; } = new List<ScheduleTargetGroup>();
+    
+    public DayOfWeekFlags DaysOfWeek { get; set; }
+    public DateOnly? ScheduledDate { get; set; } // If set, this is a one-time event
+    public TimeOnly StartTime { get; set; }
+    public TimeOnly EndTime { get; set; }
+    public int Priority { get; set; } // higher wins on overlap
+    public bool IsActive { get; set; }
+    
+    // Navigation property
+    public Playlist Playlist { get; set; } = null!;
+}
+
+public class ScheduleTargetGroup
+{
+    public int Id { get; set; }
+    public int ScheduleId { get; set; }
+    public string GroupName { get; set; } = string.Empty;
+
+    // Navigation property
+    [JsonIgnore]
+    public Schedule Schedule { get; set; } = null!;
+}


### PR DESCRIPTION
Add Schedule model, ScheduleService, ScheduleApi, and admin UI for managing time-based playlist assignments per device group. Heartbeat response now includes active playlist file list so players switch content dynamically. Includes EF Core migrations for Schedule table and group default playlist support.

## Summary

<!-- What does this PR do? -->

## Closes

<!-- Link the issue this PR resolves — GitHub will auto-close it on merge -->
Closes #19

## Checklist

- [ ] `dotnet build` passes
- [ ] `dotnet test` passes (if tests exist)
- [ ] EF migration added for schema changes
- [ ] No `var` used; explicit types throughout
