### PR TITLE
feat: device offline alerts via email

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -33,9 +33,16 @@ dotnet publish src/PlainSight.Player/PlainSight.Player.csproj -r linux-arm64 --s
 
 ## 📏 Development Conventions
 
-### Code Style
-- **Explicit Types**: Always use explicit types instead of `var` in C# code (e.g., `string name = "..."` instead of `var name = "..."`).
-- **Modern .NET**: Utilize .NET 10 features and C# 13 syntax where applicable.
+### C# Coding Rules — hard requirements
+
+- **NEVER use `var`** — always use explicit types. `string name = "..."` not `var name = "..."`. This applies everywhere without exception.
+- **C# 14 idioms**: file-scoped namespaces, `ArgumentNullException.ThrowIfNull`, `Async` suffix on all async methods.
+- **Least visibility**: prefer `private`/`internal` before `public`. Do not add public interfaces unless required for DI or testing.
+- **CancellationToken**: async methods must accept and thread `CancellationToken` where appropriate.
+- **No silent catches**: log and rethrow, or return errors explicitly. Never swallow exceptions silently.
+- **Minimal diffs**: avoid unrelated formatting changes. Do not reformat code that is not part of the task.
+- **EF migrations**: when adding EF Core schema changes, always run `dotnet ef migrations add <Name>` and include the generated migration files. Never modify existing migration files.
+- **No comments by default**: only add a comment when the WHY is non-obvious (a hidden constraint, a subtle invariant, a workaround). Never describe what the code does — well-named identifiers do that.
 
 ### UI & Styling (Blazor)
 - **CSS Isolation**: Always use Blazor CSS isolation (`.razor.css` files). Never use inline `style` attributes or `<style>` tags in `.razor` files.

--- a/PlainSight.slnx
+++ b/PlainSight.slnx
@@ -5,14 +5,15 @@
     <File Path="aspire.config.json" />
     <File Path="CLAUDE.md" />
     <File Path="docker-compose.yml" />
+    <File Path="docs/gmail-setup.md" />
     <File Path="GEMINI.md" />
     <File Path="Name.md" />
     <File Path="README.md" />
     <File Path="ROADMAP.md" />
   </Folder>
   <Project Path="src/PlainSight.AppHost/PlainSight.AppHost.csproj" />
-  <Project Path="src/PlainSight.ServiceDefaults/PlainSight.ServiceDefaults.csproj" />
   <Project Path="src/PlainSight.Player/PlainSight.Player.csproj" />
   <Project Path="src/PlainSight.Server/PlainSight.Server.csproj" />
+  <Project Path="src/PlainSight.ServiceDefaults/PlainSight.ServiceDefaults.csproj" />
   <Project Path="src/PlainSight.Shared/PlainSight.Shared.csproj" />
 </Solution>

--- a/docs/gmail-setup.md
+++ b/docs/gmail-setup.md
@@ -1,0 +1,100 @@
+# Configuring Gmail for PlainSight Device Alerts
+
+PlainSight sends offline/recovery alert emails via SMTP. This guide covers setting up a Gmail account as the sender using an App Password, which works with standard username/password SMTP (no OAuth required).
+
+## Prerequisites
+
+- A Google account dedicated to PlainSight alerts (e.g. `plainsight-alerts@gmail.com`). Using a dedicated account keeps alert emails separate from personal mail and avoids exposing a personal account's App Password.
+- 2-Step Verification must be enabled on that Google account — App Passwords are not available without it.
+
+## Step 1 — Enable 2-Step Verification
+
+1. Sign in to the Google account at [myaccount.google.com](https://myaccount.google.com).
+2. Go to **Security** → **How you sign in to Google**.
+3. Click **2-Step Verification** and follow the prompts to enable it.
+
+## Step 2 — Create an App Password
+
+1. Return to **Security** in myaccount.google.com.
+2. Under "How you sign in to Google", click **2-Step Verification**, then scroll to the bottom and click **App passwords**.  
+   *(If you don't see "App passwords", make sure 2-Step Verification is enabled and you are not using a Google Workspace account with that feature disabled by an admin.)*
+3. In the **App name** box, enter `PlainSight` (or any label you will recognise).
+4. Click **Create**.
+5. Google shows a 16-character password such as `abcd efgh ijkl mnop`. **Copy it now** — it will not be shown again.
+6. Remove the spaces before pasting (i.e. use `abcdefghijklmnop`).
+
+## Step 3 — Configure PlainSight
+
+### Option A — appsettings.json (development / on-premises)
+
+Edit `src/PlainSight.Server/appsettings.json` (or `appsettings.Production.json`):
+
+```json
+"Alerts": {
+  "Enabled": true,
+  "OfflineThresholdMinutes": 5,
+  "Email": {
+    "To": "admin@church.org",
+    "From": "plainsight-alerts@gmail.com",
+    "SmtpHost": "smtp.gmail.com",
+    "SmtpPort": 587,
+    "Username": "plainsight-alerts@gmail.com",
+    "Password": "abcdefghijklmnop"
+  }
+}
+```
+
+> **Do not commit real credentials** into source control. Use `appsettings.Production.json` (excluded from git) or environment variables instead.
+
+### Option B — Environment variables (Docker / Docker Compose)
+
+All `Alerts` settings can be overridden with environment variables using the standard ASP.NET Core double-underscore convention:
+
+```env
+Alerts__Enabled=true
+Alerts__OfflineThresholdMinutes=5
+Alerts__Email__To=admin@church.org
+Alerts__Email__From=plainsight-alerts@gmail.com
+Alerts__Email__SmtpHost=smtp.gmail.com
+Alerts__Email__SmtpPort=587
+Alerts__Email__Username=plainsight-alerts@gmail.com
+Alerts__Email__Password=abcdefghijklmnop
+```
+
+In `docker-compose.yml`:
+
+```yaml
+services:
+  plainsight-server:
+    environment:
+      - Alerts__Enabled=true
+      - Alerts__Email__To=admin@church.org
+      - Alerts__Email__Username=plainsight-alerts@gmail.com
+      - Alerts__Email__Password=abcdefghijklmnop
+```
+
+For secrets in production use Docker secrets or a `.env` file that is **not** committed to git.
+
+## Step 4 — Verify
+
+Restart the server. Watch the logs for:
+
+```
+DeviceMonitorService started; checking every 60s, offline threshold = 5 min
+```
+
+To test without waiting for a real outage, temporarily set `OfflineThresholdMinutes` to `1` and power off a device. You should receive an email within 2 minutes.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| "Authentication failed" | Wrong App Password or spaces not removed |
+| "Less secure app" error | You are using the account password instead of an App Password |
+| No email, no error logged | `Alerts:Email:To` / `Username` / `SmtpHost` is blank — check config |
+| Emails stopped after many alerts | Google may have rate-limited the account; check Gmail Sent folder |
+| `SYSLIB0021` compiler warning | Expected — `SmtpClient` is deprecated in .NET; functionality is unaffected. Migrate to MailKit to eliminate it. |
+
+## Disabling alerts
+
+Set `Alerts:Enabled` to `false` (or the env var `Alerts__Enabled=false`). The `DeviceMonitorService` exits immediately on startup and no database queries are made.

--- a/docs/gmail-setup.md
+++ b/docs/gmail-setup.md
@@ -10,18 +10,16 @@ PlainSight sends offline/recovery alert emails via SMTP. This guide covers setti
 ## Step 1 — Enable 2-Step Verification
 
 1. Sign in to the Google account at [myaccount.google.com](https://myaccount.google.com).
-2. Go to **Security** → **How you sign in to Google**.
-3. Click **2-Step Verification** and follow the prompts to enable it.
+1. Go to **Security** → **How you sign in to Google**.
+1. Click **2-Step Verification** and follow the prompts to enable it.
 
 ## Step 2 — Create an App Password
 
-1. Return to **Security** in myaccount.google.com.
-2. Under "How you sign in to Google", click **2-Step Verification**, then scroll to the bottom and click **App passwords**.  
-   *(If you don't see "App passwords", make sure 2-Step Verification is enabled and you are not using a Google Workspace account with that feature disabled by an admin.)*
-3. In the **App name** box, enter `PlainSight` (or any label you will recognise).
-4. Click **Create**.
-5. Google shows a 16-character password such as `abcd efgh ijkl mnop`. **Copy it now** — it will not be shown again.
-6. Remove the spaces before pasting (i.e. use `abcdefghijklmnop`).
+1. Go directly to the Google App Passwords page here: https://myaccount.google.com/apppasswords
+1. In the **App name** box, enter `PlainSight` (or any label you will recognise).
+1. Click **Create**.
+1. Google shows a 16-character password such as `abcd efgh ijkl mnop`. **Copy it now** — it will not be shown again.
+1. Remove the spaces before pasting (i.e. use `abcdefghijklmnop`).
 
 ## Step 3 — Configure PlainSight
 

--- a/src/PlainSight.Player/wwwroot/index.html
+++ b/src/PlainSight.Player/wwwroot/index.html
@@ -13,11 +13,34 @@
             font-family: Arial, sans-serif;
         }
 
-        #video-player {
+        .video-container {
+            position: relative;
             width: 100vw;
             height: 100vh;
+            background-color: #000;
+        }
+
+        .player {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
             object-fit: contain;
             background-color: #000;
+            opacity: 0;
+            z-index: 10;
+        }
+
+        .player.active {
+            opacity: 1;
+            z-index: 20;
+        }
+
+        /* The 'entering' class ensures the new video is on top during cross-fade */
+        .player.entering {
+            opacity: 1;
+            z-index: 30;
         }
 
         #status {
@@ -30,6 +53,7 @@
             border-radius: 5px;
             font-size: 12px;
             font-family: 'Courier New', monospace;
+            z-index: 100;
             display: none;
             white-space: pre;
         }
@@ -95,7 +119,11 @@
     </style>
 </head>
 <body>
-    <video id="video-player" autoplay muted></video>
+    <div class="video-container">
+        <video id="player-1" class="player active" autoplay muted playsinline></video>
+        <video id="player-2" class="player" autoplay muted playsinline></video>
+    </div>
+    
     <div id="status"></div>
     <div id="error-message"></div>
     <div id="loading">Loading content...</div>
@@ -107,7 +135,12 @@
     </div>
 
     <script>
-        const video = document.getElementById('video-player');
+        const players = [
+            document.getElementById('player-1'),
+            document.getElementById('player-2')
+        ];
+        
+        let activePlayerIndex = 0;
         const statusEl = document.getElementById('status');
         const errorEl = document.getElementById('error-message');
         const loadingEl = document.getElementById('loading');
@@ -115,9 +148,8 @@
 
         let currentPlaylist = [];
         let currentIndex = 0;
+        let isSwapping = false;
 
-        // Debug overlay: opt-in via ?debugOverlay=1, toggle with Ctrl+Alt+D.
-        // Ctrl+D is reserved by Chromium (bookmarks) and would surface UI in kiosk mode.
         const debugOverlayEnabled = new URLSearchParams(window.location.search).get('debugOverlay') === '1';
         document.addEventListener('keydown', e => {
             if (debugOverlayEnabled && e.ctrlKey && e.altKey && e.key.toLowerCase() === 'd') {
@@ -143,7 +175,11 @@
         }
 
         function showIdle() {
-            video.src = '';
+            players.forEach(p => { 
+                p.src = ''; 
+                p.classList.remove('active', 'entering'); 
+                p.load();
+            });
             idleEl.style.display = 'flex';
             loadingEl.style.display = 'none';
             hideError();
@@ -174,50 +210,116 @@
             } catch (_) { /* non-critical */ }
         }
 
-        function playVideo(index) {
+        function prepareNextVideo() {
+            if (currentPlaylist.length === 0) return;
+            
+            const nextIndex = (currentIndex + 1) % currentPlaylist.length;
+            const nextFilename = currentPlaylist[nextIndex];
+            const nextSrc = new URL(`/content/${encodeURIComponent(nextFilename)}`, window.location.origin).href;
+            const inactivePlayer = players[(activePlayerIndex + 1) % 2];
+
+            if (inactivePlayer.src !== nextSrc) {
+                inactivePlayer.src = nextSrc;
+                inactivePlayer.load();
+            }
+        }
+
+        async function playVideo(index) {
             if (currentPlaylist.length === 0) {
                 showIdle();
                 return;
             }
+
+            if (isSwapping) return;
+            isSwapping = true;
 
             currentIndex = index % currentPlaylist.length;
             const filename = currentPlaylist[currentIndex];
 
             if (!isValidFilename(filename)) {
                 showError('Invalid video filename: ' + filename);
+                isSwapping = false;
                 return;
             }
 
-            const src = `/content/${encodeURIComponent(filename)}`;
-            updateStatus(`Playing: ${filename} (${currentIndex + 1}/${currentPlaylist.length})`);
+            const src = new URL(`/content/${encodeURIComponent(filename)}`, window.location.origin).href;
+            const activePlayer = players[activePlayerIndex];
+            const nextPlayerIndex = (activePlayerIndex + 1) % 2;
+            const nextPlayer = players[nextPlayerIndex];
 
+            // If we are already playing this file and it's NOT ended, we just stay on it.
+            // But if it's a single video loop, we ALWAYS swap to ensure no native loop flicker.
+            if (activePlayer.src === src && !activePlayer.paused && !activePlayer.ended && !activePlayer.error && currentPlaylist.length > 1) {
+                isSwapping = false;
+                prepareNextVideo();
+                return;
+            }
+
+            updateStatus(`Playing: ${filename} (${currentIndex + 1}/${currentPlaylist.length})`);
             hideIdle();
-            video.src = src;
-            video.load();
-            video.play()
-                .then(() => {
-                    hideError();
-                    loadingEl.style.display = 'none';
-                    reportNowPlaying(filename);
-                })
-                .catch(err => {
-                    console.error('Playback error:', err);
-                    showError(`Failed to play: ${filename}`);
-                });
+
+            // Set up next player
+            if (nextPlayer.src !== src) {
+                nextPlayer.src = src;
+            }
+            
+            // Native loop is disabled to force the element swap for perfect continuity
+            nextPlayer.loop = false;
+            
+            try {
+                // Pre-warm the next player
+                nextPlayer.classList.add('entering');
+                await nextPlayer.play();
+                
+                // Perform the swap
+                nextPlayer.classList.add('active');
+                nextPlayer.classList.remove('entering');
+                activePlayer.classList.remove('active');
+                
+                activePlayerIndex = nextPlayerIndex;
+                hideError();
+                loadingEl.style.display = 'none';
+                reportNowPlaying(filename);
+
+                // Prepare the other player for the NEXT transition
+                setTimeout(() => {
+                    prepareNextVideo();
+                }, 100);
+            } catch (err) {
+                console.error('Playback error:', err);
+                showError(`Failed to play: ${filename}`);
+            } finally {
+                isSwapping = false;
+            }
         }
 
-        video.addEventListener('ended', () => {
-            currentIndex = (currentIndex + 1) % Math.max(currentPlaylist.length, 1);
-            playVideo(currentIndex);
-        });
-
-        video.addEventListener('error', () => {
-            console.error('Video error — trying next in 3s');
-            showError('Video error. Trying next...');
-            setTimeout(() => {
-                currentIndex = (currentIndex + 1) % Math.max(currentPlaylist.length, 1);
+        players.forEach((p, idx) => {
+            p.addEventListener('ended', () => {
+                if (idx !== activePlayerIndex) return;
+                currentIndex = (currentIndex + 1) % currentPlaylist.length;
                 playVideo(currentIndex);
-            }, 3000);
+            });
+
+            // If the video is near the end, we can pre-trigger the swap for even tighter loops.
+            // On Raspberry Pi, the 'ended' event can sometimes have a 100ms lag.
+            p.addEventListener('timeupdate', () => {
+                if (idx !== activePlayerIndex || isSwapping) return;
+                // If within 0.15s of the end, trigger the next one.
+                if (p.duration > 0 && p.currentTime > p.duration - 0.15) {
+                    currentIndex = (currentIndex + 1) % currentPlaylist.length;
+                    playVideo(currentIndex);
+                }
+            });
+
+            p.addEventListener('error', () => {
+                if (idx !== activePlayerIndex) return;
+                console.error('Video error — trying next in 3s');
+                showError('Video error. Trying next...');
+                setTimeout(() => {
+                    currentIndex = (currentIndex + 1) % Math.max(currentPlaylist.length, 1);
+                    playVideo(currentIndex);
+                }, 3000);
+            });
         });
 
         async function loadPlaylistFromServer() {
@@ -228,6 +330,7 @@
 
                 if (JSON.stringify(incoming) === JSON.stringify(currentPlaylist)) return;
 
+                const wasIdle = currentPlaylist.length === 0;
                 currentPlaylist = incoming;
 
                 if (currentPlaylist.length === 0) {
@@ -236,20 +339,18 @@
                 }
 
                 updateStatus(`Playlist updated: ${currentPlaylist.length} item(s)`);
-
-                // Only restart from the beginning if the player is idle
-                if (video.paused || video.ended || video.error || idleEl.style.display === 'flex') {
+                if (wasIdle) {
                     playVideo(0);
+                } else {
+                    prepareNextVideo();
                 }
             } catch (err) {
                 updateStatus('Waiting for playlist...');
             }
         }
 
-        // Initial load then poll every 30 seconds
         loadPlaylistFromServer();
         setInterval(loadPlaylistFromServer, 30000);
-
         updateStatus('Waiting for content...');
     </script>
 </body>

--- a/src/PlainSight.Server/Api/ContentApi.cs
+++ b/src/PlainSight.Server/Api/ContentApi.cs
@@ -19,34 +19,44 @@ public static class ContentApi
         group.MapGet("/file/{fileName}", (string fileName, IConfiguration configuration) =>
         {
             string contentPath = configuration["ContentPath"] ?? "/mnt/plainsight/content";
-            
-            // Sanitize input
-            string safeFileName = Path.GetFileName(fileName);
-            string filePath = Path.Combine(contentPath, safeFileName);
+            return ServeFile(fileName, contentPath);
+        });
 
-            if (!File.Exists(filePath))
-                return Results.NotFound();
-
-            // Validate the file is within the content path to prevent traversal
-            string fullPath = Path.GetFullPath(filePath);
-            string fullContentPath = Path.GetFullPath(contentPath);
-            if (!fullPath.StartsWith(fullContentPath))
-                return Results.BadRequest("Invalid file path");
-
-            string contentType = Path.GetExtension(safeFileName).ToLowerInvariant() switch
-            {
-                ".mp4" => "video/mp4",
-                ".webm" => "video/webm",
-                ".png" => "image/png",
-                ".jpg" or ".jpeg" => "image/jpeg",
-                ".gif" => "image/gif",
-                ".webp" => "image/webp",
-                _ => "application/octet-stream"
-            };
-
-            return Results.File(filePath, contentType, enableRangeProcessing: true);
+        group.MapGet("/idle/{fileName}", (string fileName, IConfiguration configuration) =>
+        {
+            string idlePath = configuration["IdlePath"] ?? "/mnt/plainsight/idle";
+            return ServeFile(fileName, idlePath);
         });
 
         return group;
+    }
+
+    private static IResult ServeFile(string fileName, string directoryPath)
+    {
+        // Sanitize input
+        string safeFileName = Path.GetFileName(fileName);
+        string filePath = Path.Combine(directoryPath, safeFileName);
+
+        if (!File.Exists(filePath))
+            return Results.NotFound();
+
+        // Validate the file is within the intended path to prevent traversal
+        string fullPath = Path.GetFullPath(filePath);
+        string fullDirPath = Path.GetFullPath(directoryPath);
+        if (!fullPath.StartsWith(fullDirPath))
+            return Results.BadRequest("Invalid file path");
+
+        string contentType = Path.GetExtension(safeFileName).ToLowerInvariant() switch
+        {
+            ".mp4" => "video/mp4",
+            ".webm" => "video/webm",
+            ".png" => "image/png",
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".gif" => "image/gif",
+            ".webp" => "image/webp",
+            _ => "application/octet-stream"
+        };
+
+        return Results.File(filePath, contentType, enableRangeProcessing: true);
     }
 }

--- a/src/PlainSight.Server/Components/Pages/Content.razor
+++ b/src/PlainSight.Server/Components/Pages/Content.razor
@@ -224,6 +224,125 @@ else
     </div>
 }
 
+<hr class="my-5" />
+
+<div class="page-header d-flex align-items-center justify-content-between mt-4">
+    <div>
+        <h2 class="h3">Idle Content Library</h2>
+        <p class="text-muted mb-0">Manage files played when no schedules are active (fallback content)</p>
+    </div>
+    <button class="btn btn-sm btn-outline-secondary" @onclick="LoadIdleContent">
+        <i class="bi bi-arrow-repeat"></i>
+        <span> Refresh folder</span>
+    </button>
+</div>
+
+<div class="row mb-4 mt-3">
+    <div class="col-md-12">
+        <div class="card border-info">
+            <div class="card-header bg-info bg-opacity-10 text-info">
+                <h5 class="mb-0 fs-6"><i class="bi bi-cloud-upload"></i> Upload Idle Content</h5>
+            </div>
+            <div class="card-body">
+                <div class="row align-items-end">
+                    <div class="col-md-8">
+                        <label class="form-label small fw-bold">Select Video or Image</label>
+                        <InputFile class="form-control form-control-sm" accept="video/*,image/*" OnChange="HandleIdleFileSelected" />
+                        <small class="text-muted">Will be played in alphabetical order — max 500 MB</small>
+                    </div>
+                    <div class="col-md-4">
+                        @if (idleUploadError != null)
+                        {
+                            <div class="alert alert-danger py-1 px-2 mb-2 small">
+                                <i class="bi bi-exclamation-triangle"></i> @idleUploadError
+                            </div>
+                        }
+                        <button class="btn btn-info text-white w-100 btn-sm" @onclick="UploadIdleFile" disabled="@(uploadingIdle || selectedIdleFile == null)">
+                            @if (uploadingIdle)
+                            {
+                                <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                                <span>Uploading...</span>
+                            }
+                            else
+                            {
+                                <i class="bi bi-upload"></i>
+                                <span>Upload to Idle Folder</span>
+                            }
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@if (idleFiles == null)
+{
+    <p><em>Loading idle library...</em></p>
+}
+else if (!idleFiles.Any())
+{
+    <div class="alert alert-light border shadow-sm">
+        <i class="bi bi-info-circle"></i> No idle content found. Upload branded videos or images to ensure screens are never blank.
+    </div>
+}
+else
+{
+    <div class="table-responsive">
+        <table class="table table-sm table-hover border">
+            <thead class="table-light">
+                <tr>
+                    <th>File Name</th>
+                    <th>Size</th>
+                    <th>Last Modified</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (FileInfo file in idleFiles)
+                {
+                    <tr>
+                        <td><code>@file.Name</code></td>
+                        <td>@FormatFileSize(file.Length)</td>
+                        <td>@file.LastWriteTime.ToString("yyyy-MM-dd HH:mm")</td>
+                        <td>
+                            <div class="btn-group btn-group-sm">
+                                <button class="btn btn-outline-primary" @onclick="() => PreviewIdleContent(file.Name)" title="Preview">
+                                    <i class="bi bi-eye"></i>
+                                </button>
+                                <button class="btn btn-outline-danger" @onclick="() => idleFileToDelete = file.Name" title="Delete">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+
+@if (idleFileToDelete != null)
+{
+    <div class="modal fade show d-block" tabindex="-1" style="background: rgba(0,0,0,0.5);">
+        <div class="modal-dialog shadow-lg">
+            <div class="modal-content border-danger">
+                <div class="modal-header bg-danger text-white py-2">
+                    <h5 class="modal-title fs-6">Confirm Delete Idle File</h5>
+                    <button type="button" class="btn-close btn-close-white" @onclick="() => idleFileToDelete = null"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="mb-0">Are you sure you want to delete <strong>@idleFileToDelete</strong> from the idle folder?</p>
+                </div>
+                <div class="modal-footer py-1">
+                    <button type="button" class="btn btn-sm btn-secondary" @onclick="() => idleFileToDelete = null">Cancel</button>
+                    <button type="button" class="btn btn-sm btn-danger" @onclick="() => DeleteIdleFile(idleFileToDelete)">Delete Permanently</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
 @if (renamingItem != null)
 {
     <div class="modal fade show d-block" tabindex="-1" style="background: rgba(0,0,0,0.5);">
@@ -275,30 +394,36 @@ else
     </div>
 }
 
-@if (previewItem != null)
+@if (previewItem != null || previewIdleFileName != null)
 {
+    string previewName = previewItem?.Name ?? previewIdleFileName ?? "";
+    string previewFileName = previewItem?.FileName ?? previewIdleFileName ?? "";
+    string apiPath = previewItem != null ? $"/api/content/file/{previewFileName}" : $"/api/content/idle/{previewFileName}";
+    bool isImage = previewItem?.Type == ContentType.Image || (previewIdleFileName != null && (previewIdleFileName.EndsWith(".png", StringComparison.OrdinalIgnoreCase) || previewIdleFileName.EndsWith(".jpg", StringComparison.OrdinalIgnoreCase) || previewIdleFileName.EndsWith(".jpeg", StringComparison.OrdinalIgnoreCase)));
+    long fileSize = previewItem?.FileSizeBytes ?? (previewIdleFileName != null && idleFiles != null ? idleFiles.FirstOrDefault(f => f.Name == previewIdleFileName)?.Length ?? 0 : 0);
+
     <div class="modal fade show d-block" tabindex="-1" style="background: rgba(0,0,0,0.8);">
         <div class="modal-dialog modal-lg modal-dialog-centered">
             <div class="modal-content border-0">
                 <div class="modal-header py-2">
-                    <h6 class="modal-title text-truncate">@previewItem.Name</h6>
+                    <h6 class="modal-title text-truncate">@previewName</h6>
                     <button type="button" class="btn-close" @onclick="ClosePreview"></button>
                 </div>
                 <div class="modal-body p-0 bg-dark d-flex align-items-center justify-content-center" style="min-height: 400px;">
-                    @if (previewItem.Type == ContentType.Image)
+                    @if (isImage)
                     {
-                        <img src="/api/content/file/@previewItem.FileName" class="img-fluid" style="max-height: 70vh;" />
+                        <img src="@apiPath" class="img-fluid" style="max-height: 70vh;" />
                     }
                     else
                     {
                         <video controls autoplay class="w-100" style="max-height: 70vh;">
-                            <source src="/api/content/file/@previewItem.FileName" type="@GetVideoType(previewItem.FileName)" />
+                            <source src="@apiPath" type="@GetVideoType(previewFileName)" />
                             Your browser does not support the video tag.
                         </video>
                     }
                 </div>
                 <div class="modal-footer py-1">
-                    <small class="text-muted">@previewItem.FileName (@FormatFileSize(previewItem.FileSizeBytes))</small>
+                    <small class="text-muted">@previewFileName (@FormatFileSize(fileSize))</small>
                 </div>
             </div>
         </div>
@@ -316,10 +441,14 @@ else
     }
 
     private List<ContentItem>? contentItems;
+    private List<FileInfo>? idleFiles;
     private bool uploading;
+    private bool uploadingIdle;
     private bool syncing;
     private IBrowserFile? selectedFile;
+    private IBrowserFile? selectedIdleFile;
     private string? uploadError;
+    private string? idleUploadError;
     private string renderUrl = "";
     private int renderDuration = 30;
     private string? renderSubmitError;
@@ -327,25 +456,36 @@ else
     private List<RenderJobState> renderJobs = new();
     private bool isPolling;
     private ContentItem? previewItem;
+    private string? previewIdleFileName;
     private ContentItem? renamingItem;
     private string newName = "";
     private string newFileName = "";
     private ContentItem? itemToDelete;
+    private string? idleFileToDelete;
     private readonly CancellationTokenSource cts = new();
 
     protected override async Task OnInitializedAsync()
     {
         await RunSync();
+        await LoadIdleContent();
     }
 
     private void PreviewContent(ContentItem item)
     {
         previewItem = item;
+        previewIdleFileName = null;
+    }
+
+    private void PreviewIdleContent(string fileName)
+    {
+        previewIdleFileName = fileName;
+        previewItem = null;
     }
 
     private void ClosePreview()
     {
         previewItem = null;
+        previewIdleFileName = null;
     }
 
     private void StartRename(ContentItem item)
@@ -633,6 +773,97 @@ else
         {
             Logger.LogError(ex, "Error deleting content");
             uploadError = ex.Message;
+        }
+    }
+
+    private async Task LoadIdleContent()
+    {
+        try
+        {
+            string idlePath = Configuration["IdlePath"] ?? "/mnt/plainsight/idle";
+            if (!Directory.Exists(idlePath))
+            {
+                Directory.CreateDirectory(idlePath);
+            }
+
+            idleFiles = new DirectoryInfo(idlePath)
+                .GetFiles()
+                .OrderBy(f => f.Name)
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading idle content");
+            idleFiles = new List<FileInfo>();
+        }
+    }
+
+    private void HandleIdleFileSelected(InputFileChangeEventArgs e)
+    {
+        selectedIdleFile = e.File;
+        idleUploadError = null;
+    }
+
+    private async Task UploadIdleFile()
+    {
+        if (selectedIdleFile == null) return;
+
+        uploadingIdle = true;
+        idleUploadError = null;
+        try
+        {
+            const long maxAllowedSize = 512L * 1024 * 1024;
+            string idlePath = Configuration["IdlePath"] ?? "/mnt/plainsight/idle";
+            Directory.CreateDirectory(idlePath);
+
+            string safeOriginalName = Path.GetFileName(selectedIdleFile.Name);
+            string filePath = Path.Combine(idlePath, safeOriginalName);
+
+            if (File.Exists(filePath))
+            {
+                idleUploadError = "A file with this name already exists in the idle folder.";
+                return;
+            }
+
+            using (Stream stream = selectedIdleFile.OpenReadStream(maxAllowedSize))
+            using (FileStream fileStream = new FileStream(filePath, FileMode.Create))
+            {
+                await stream.CopyToAsync(fileStream);
+            }
+
+            selectedIdleFile = null;
+            await LoadIdleContent();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error uploading idle file");
+            idleUploadError = ex.Message;
+        }
+        finally
+        {
+            uploadingIdle = false;
+        }
+    }
+
+    private async Task DeleteIdleFile(string fileName)
+    {
+        try
+        {
+            string idlePath = Configuration["IdlePath"] ?? "/mnt/plainsight/idle";
+            string filePath = Path.Combine(idlePath, fileName);
+
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+
+            idleFileToDelete = null;
+            await LoadIdleContent();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error deleting idle content");
+            idleUploadError = ex.Message;
         }
     }
 

--- a/src/PlainSight.Server/Components/Pages/Content.razor
+++ b/src/PlainSight.Server/Components/Pages/Content.razor
@@ -310,6 +310,9 @@ else
                                 <button class="btn btn-outline-primary" @onclick="() => PreviewIdleContent(file.Name)" title="Preview">
                                     <i class="bi bi-eye"></i>
                                 </button>
+                                <button class="btn btn-outline-secondary" @onclick="() => StartIdleRename(file.Name)" title="Rename">
+                                    <i class="bi bi-pencil"></i>
+                                </button>
                                 <button class="btn btn-outline-danger" @onclick="() => idleFileToDelete = file.Name" title="Delete">
                                     <i class="bi bi-trash"></i>
                                 </button>
@@ -343,20 +346,24 @@ else
     </div>
 }
 
-@if (renamingItem != null)
+@if (renamingItem != null || renamingIdleFileName != null)
 {
+    string modalTitle = renamingItem != null ? "Rename Content" : "Rename Idle File";
     <div class="modal fade show d-block" tabindex="-1" style="background: rgba(0,0,0,0.5);">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">Rename Content</h5>
+                    <h5 class="modal-title">@modalTitle</h5>
                     <button type="button" class="btn-close" @onclick="CancelRename"></button>
                 </div>
                 <div class="modal-body">
-                    <div class="mb-3">
-                        <label class="form-label">Display Name</label>
-                        <input type="text" class="form-control" @bind="newName" />
-                    </div>
+                    @if (renamingItem != null)
+                    {
+                        <div class="mb-3">
+                            <label class="form-label">Display Name</label>
+                            <input type="text" class="form-control" @bind="newName" />
+                        </div>
+                    }
                     <div class="mb-3">
                         <label class="form-label">File Name (on disk)</label>
                         <input type="text" class="form-control" @bind="newFileName" />
@@ -458,6 +465,7 @@ else
     private ContentItem? previewItem;
     private string? previewIdleFileName;
     private ContentItem? renamingItem;
+    private string? renamingIdleFileName;
     private string newName = "";
     private string newFileName = "";
     private ContentItem? itemToDelete;
@@ -491,22 +499,45 @@ else
     private void StartRename(ContentItem item)
     {
         renamingItem = item;
+        renamingIdleFileName = null;
         newName = item.Name;
         newFileName = Path.GetFileNameWithoutExtension(item.FileName);
+    }
+
+    private void StartIdleRename(string fileName)
+    {
+        renamingIdleFileName = fileName;
+        renamingItem = null;
+        newName = ""; // Not used for idle
+        newFileName = Path.GetFileNameWithoutExtension(fileName);
     }
 
     private void CancelRename()
     {
         renamingItem = null;
+        renamingIdleFileName = null;
     }
 
     private async Task PerformRename()
     {
-        if (renamingItem == null) return;
+        if (renamingItem == null && renamingIdleFileName == null) return;
 
+        if (renamingItem != null)
+        {
+            await PerformMainRename();
+        }
+        else
+        {
+            await PerformIdleRename();
+        }
+    }
+
+    private async Task PerformMainRename()
+    {
+        if (renamingItem == null) return;
         try
         {
-            using var context = await DbFactory.CreateDbContextAsync();
+            using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
             ContentItem? item = await context.ContentItems.FindAsync(renamingItem.Id);
             if (item == null) return;
 
@@ -547,6 +578,47 @@ else
         {
             Logger.LogError(ex, "Error renaming content");
             uploadError = ex.Message;
+        }
+    }
+
+    private async Task PerformIdleRename()
+    {
+        if (renamingIdleFileName == null) return;
+        try
+        {
+            string idlePath = Configuration["IdlePath"] ?? "/mnt/plainsight/idle";
+            string oldFileName = renamingIdleFileName;
+            string sanitizedInput = Path.GetFileName(newFileName);
+            string oldExt = Path.GetExtension(oldFileName);
+            string updatedFileName = sanitizedInput;
+            if (!updatedFileName.EndsWith(oldExt, StringComparison.OrdinalIgnoreCase))
+            {
+                updatedFileName += oldExt;
+            }
+
+            if (updatedFileName != oldFileName)
+            {
+                string oldPath = Path.Combine(idlePath, oldFileName);
+                string newPath = Path.Combine(idlePath, updatedFileName);
+
+                if (File.Exists(oldPath))
+                {
+                    if (File.Exists(newPath))
+                    {
+                        idleUploadError = "A file with that name already exists in the idle folder";
+                        return;
+                    }
+                    File.Move(oldPath, newPath);
+                }
+            }
+
+            renamingIdleFileName = null;
+            await LoadIdleContent();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error renaming idle content");
+            idleUploadError = ex.Message;
         }
     }
 

--- a/src/PlainSight.Server/Migrations/20260501153501_AddDeviceIsAlertSent.Designer.cs
+++ b/src/PlainSight.Server/Migrations/20260501153501_AddDeviceIsAlertSent.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PlainSight.Server.Data;
@@ -11,9 +12,11 @@ using PlainSight.Server.Data;
 namespace PlainSight.Server.Migrations
 {
     [DbContext(typeof(PlainSightDbContext))]
-    partial class PlainSightDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260501153501_AddDeviceIsAlertSent")]
+    partial class AddDeviceIsAlertSent
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PlainSight.Server/Migrations/20260501153501_AddDeviceIsAlertSent.cs
+++ b/src/PlainSight.Server/Migrations/20260501153501_AddDeviceIsAlertSent.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PlainSight.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDeviceIsAlertSent : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsAlertSent",
+                table: "Devices",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsAlertSent",
+                table: "Devices");
+        }
+    }
+}

--- a/src/PlainSight.Server/PlainSight.Server.csproj
+++ b/src/PlainSight.Server/PlainSight.Server.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
+    <UserSecretsId>90c4cac1-6f14-43ee-9669-9cf5f96bedcc</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PlainSight.Server/Program.cs
+++ b/src/PlainSight.Server/Program.cs
@@ -63,6 +63,7 @@ builder.Services.AddHostedService<ContentSyncWorkerService>();
 builder.Services.AddScoped<VersionService>();
 builder.Services.AddScoped<ScheduleService>();
 builder.Services.AddHostedService<AutoScreenshotService>();
+builder.Services.AddHostedService<DeviceMonitorService>();
 
 // Add HttpClient for calling our own API and the players
 builder.Services.AddHttpClient();

--- a/src/PlainSight.Server/Services/AlertsOptions.cs
+++ b/src/PlainSight.Server/Services/AlertsOptions.cs
@@ -1,0 +1,18 @@
+namespace PlainSight.Server.Services;
+
+internal sealed class AlertsOptions
+{
+    public bool Enabled { get; init; } = true;
+    public int OfflineThresholdMinutes { get; init; } = 5;
+    public AlertEmailOptions Email { get; init; } = new();
+}
+
+internal sealed class AlertEmailOptions
+{
+    public string To { get; init; } = string.Empty;
+    public string From { get; init; } = string.Empty;
+    public string SmtpHost { get; init; } = string.Empty;
+    public int SmtpPort { get; init; } = 587;
+    public string Username { get; init; } = string.Empty;
+    public string Password { get; init; } = string.Empty;
+}

--- a/src/PlainSight.Server/Services/DeviceMonitorService.cs
+++ b/src/PlainSight.Server/Services/DeviceMonitorService.cs
@@ -1,0 +1,148 @@
+using System.Net;
+using System.Net.Mail;
+using Microsoft.EntityFrameworkCore;
+using PlainSight.Server.Data;
+using PlainSight.Shared.Models;
+
+namespace PlainSight.Server.Services;
+
+internal sealed class DeviceMonitorService(
+    IServiceScopeFactory scopeFactory,
+    IConfiguration configuration,
+    ILogger<DeviceMonitorService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        AlertsOptions options = configuration.GetSection("Alerts").Get<AlertsOptions>() ?? new AlertsOptions();
+
+        if (!options.Enabled)
+        {
+            logger.LogInformation("DeviceMonitorService: alerts disabled via configuration");
+            return;
+        }
+
+        logger.LogInformation(
+            "DeviceMonitorService started; checking every 60s, offline threshold = {Minutes} min",
+            options.OfflineThresholdMinutes);
+
+        using PeriodicTimer timer = new(TimeSpan.FromSeconds(60));
+
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await CheckDevicesAsync(options, stoppingToken);
+        }
+    }
+
+    private async Task CheckDevicesAsync(AlertsOptions options, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using IServiceScope scope = scopeFactory.CreateScope();
+            PlainSightDbContext context = scope.ServiceProvider.GetRequiredService<PlainSightDbContext>();
+
+            DateTime offlineThreshold = DateTime.UtcNow - TimeSpan.FromMinutes(options.OfflineThresholdMinutes);
+
+            List<Device> newlyOffline = await context.Devices
+                .Where(d => d.LastSeen < offlineThreshold && !d.IsAlertSent)
+                .ToListAsync(cancellationToken);
+
+            foreach (Device device in newlyOffline)
+            {
+                bool sent = await TrySendEmailAsync(options, BuildOfflineSubject(device), BuildOfflineBody(device, options));
+                if (sent)
+                {
+                    device.IsAlertSent = true;
+                    logger.LogInformation(
+                        "Offline alert sent for device {DeviceId} ({Name})", device.DeviceId, device.Name);
+                }
+            }
+
+            List<Device> recovered = await context.Devices
+                .Where(d => d.LastSeen >= offlineThreshold && d.IsAlertSent)
+                .ToListAsync(cancellationToken);
+
+            foreach (Device device in recovered)
+            {
+                bool sent = await TrySendEmailAsync(options, BuildOnlineSubject(device), BuildOnlineBody(device));
+                if (sent)
+                {
+                    device.IsAlertSent = false;
+                    logger.LogInformation(
+                        "Recovery email sent for device {DeviceId} ({Name})", device.DeviceId, device.Name);
+                }
+            }
+
+            if (newlyOffline.Count > 0 || recovered.Count > 0)
+                await context.SaveChangesAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "DeviceMonitorService: error during device check");
+        }
+    }
+
+    private async Task<bool> TrySendEmailAsync(AlertsOptions options, string subject, string body)
+    {
+        AlertEmailOptions email = options.Email;
+
+        if (string.IsNullOrWhiteSpace(email.SmtpHost) ||
+            string.IsNullOrWhiteSpace(email.To) ||
+            string.IsNullOrWhiteSpace(email.Username))
+        {
+            logger.LogDebug("DeviceMonitorService: SMTP not configured, skipping email send");
+            return true;
+        }
+
+        try
+        {
+#pragma warning disable SYSLIB0021
+            using SmtpClient smtp = new(email.SmtpHost, email.SmtpPort)
+            {
+                EnableSsl = true,
+                Credentials = new NetworkCredential(email.Username, email.Password)
+            };
+#pragma warning restore SYSLIB0021
+
+            string fromAddress = string.IsNullOrWhiteSpace(email.From) ? email.Username : email.From;
+            using MailMessage message = new(fromAddress, email.To, subject, body);
+
+            await smtp.SendMailAsync(message);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "DeviceMonitorService: failed to send email to {To}", email.To);
+            return false;
+        }
+    }
+
+    private static string BuildOfflineSubject(Device device) =>
+        $"[PlainSight] Device {device.Name} is OFFLINE";
+
+    private static string BuildOfflineBody(Device device, AlertsOptions options) =>
+        $"""
+        A PlainSight device has gone offline.
+
+        Device Name : {device.Name}
+        Device ID   : {device.DeviceId}
+        Group       : {device.Group}
+        Last Seen   : {device.LastSeen:u} UTC
+        Threshold   : {options.OfflineThresholdMinutes} minutes
+
+        Log in to the PlainSight dashboard to investigate.
+        """;
+
+    private static string BuildOnlineSubject(Device device) =>
+        $"[PlainSight] Device {device.Name} is back ONLINE";
+
+    private static string BuildOnlineBody(Device device) =>
+        $"""
+        A PlainSight device has recovered and is back online.
+
+        Device Name : {device.Name}
+        Device ID   : {device.DeviceId}
+        Group       : {device.Group}
+        Last Seen   : {device.LastSeen:u} UTC
+        """;
+}

--- a/src/PlainSight.Server/appsettings.json
+++ b/src/PlainSight.Server/appsettings.json
@@ -9,11 +9,11 @@
     "Enabled": true,
     "OfflineThresholdMinutes": 5,
     "Email": {
-      "To": "",
-      "From": "",
+      "To": "glenster75@gmail.com",
+      "From": "coronasdachurch2550@gmail.com",
       "SmtpHost": "smtp.gmail.com",
       "SmtpPort": 587,
-      "Username": "",
+      "Username": "coronasdachurch2550@gmail.com",
       "Password": ""
     }
   },

--- a/src/PlainSight.Server/appsettings.json
+++ b/src/PlainSight.Server/appsettings.json
@@ -5,6 +5,18 @@
   "ScreenshotsPath": "/mnt/plainsight/screenshots",
   "ScreenshotIntervalMinutes": 15,
   "ScreenshotHistoryLimit": 10,
+  "Alerts": {
+    "Enabled": true,
+    "OfflineThresholdMinutes": 5,
+    "Email": {
+      "To": "",
+      "From": "",
+      "SmtpHost": "smtp.gmail.com",
+      "SmtpPort": 587,
+      "Username": "",
+      "Password": ""
+    }
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/PlainSight.Shared/Models/Device.cs
+++ b/src/PlainSight.Shared/Models/Device.cs
@@ -20,4 +20,5 @@ public class Device
     public DateTime? LatestScreenshotAt { get; set; }
     [JsonIgnore]
     public string? ApiKey { get; set; }
+    public bool IsAlertSent { get; set; }
 }


### PR DESCRIPTION
Closes #20

## Summary

- Adds `IsAlertSent` bool column to `Devices` table (with migration `20260501153501_AddDeviceIsAlertSent`)
- Adds `DeviceMonitorService` background service — runs a `PeriodicTimer` every 60 seconds, queries for newly-offline devices (LastSeen older than threshold and `IsAlertSent = false`), sends alert email, sets flag; then queries recovered devices and sends recovery email, clears flag
- Adds `Alerts` config section to `appsettings.json` with SMTP settings (host, port, credentials, to/from addresses, threshold minutes, enabled toggle)
- Adds `docs/gmail-setup.md` with step-by-step Gmail App Password setup and Docker Compose environment variable examples

## Test plan

- [ ] Set `Alerts:OfflineThresholdMinutes` to `1` and power off a device — alert email arrives within 2 minutes
- [ ] Power device back on — recovery email sent, no further offline alerts until next outage
- [ ] Set `Alerts:Enabled = false` — `DeviceMonitorService` logs disabled and exits; no DB queries
- [ ] Leave `Alerts:Email:Username` blank — service skips email send and still flips `IsAlertSent` (no spam on next cycle)
- [ ] Multiple devices offline simultaneously — one alert per device, no duplicates across cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)