### PR TITLE
Mission Control admin redesign

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,61 @@
+# PlainSight: Mission Control redesign
+
+Reimagines the admin dashboard as an industrial NOC-style mission control. Dark surfaces, status-at-a-glance, telemetry-first device tiles. Wires real KPIs from `PlainSightDbContext` into the top bar.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/PlainSight.Server/wwwroot/app.css` | Replaced — new dark token system, restyled Bootstrap primitives (buttons, alerts, modals, tables, forms) |
+| `src/PlainSight.Server/Components/Layout/MainLayout.razor` | Replaced — top bar now shows live system LED + active/degraded/offline KPIs (5s refresh) |
+| `src/PlainSight.Server/Components/Layout/MainLayout.razor.css` | Replaced — glassmorphism top bar, scoped KPI styles |
+| `src/PlainSight.Server/Components/Layout/NavMenu.razor` | Replaced — gradient logo mark, refined section labels, dedicated sign-out button |
+| `src/PlainSight.Server/Components/Layout/NavMenu.razor.css` | Replaced — dark nav with cyan active-state rail |
+| `src/PlainSight.Server/Components/Pages/Devices.razor` | Replaced — table swapped for status-filtered tile grid; same code-behind, same EF logic, plus `statusFilter` state and online/warn/offline split |
+| `src/PlainSight.Server/Components/Pages/Devices.razor.css` | Replaced — tile, telemetry grid, bulk-action bar, status filter chips |
+
+## Design system
+
+- **Surfaces:** `#06090F → #0A111E → #0F1A2E → #14213A` (4-step dark scale)
+- **Status:** Emerald `#10B981` · Amber `#F59E0B` · Crimson `#EF4444` (with halo glow + LED pulse)
+- **Accents:** Cyan `#22D3EE` for primary, Blue `#3B82F6` for interactive
+- **Type:** Inter (UI) + JetBrains Mono (telemetry/IDs)
+
+All tokens declared in `:root` in `app.css` (`--ps-*` namespace).
+
+## Behaviour parity
+
+Everything from the original `Devices.razor` still works:
+- 5-second auto-refresh timer (`refreshTimer`)
+- Per-device screenshot request + history modal (`ShowScreenshotHistory`)
+- Group reassignment (per-device dropdown + bulk move)
+- API key reset
+- Live mode editor (override / auto-switch / NDI source)
+- Bulk screenshot, bulk move, bulk version assignment
+
+New behaviour:
+- **Status filter chips** (`All / Online / Degraded / Offline`) — three-tier status replaces the binary online/offline (`< 60s = online`, `< 5min = degraded`, else `offline`)
+- **Top bar KPIs** — pulled from a fresh `LoadDevices`-style query in `MainLayout.razor` itself, refreshed every 5s alongside the existing per-page timer
+- **Select all visible** — only selects devices matching the current status filter
+
+## Compatibility notes
+
+1. **Bootstrap** is still in use — the redesign restyles Bootstrap classes rather than removing them. No npm/bundler changes needed.
+2. **CSS Isolation** — all new selectors in `MainLayout.razor.css`, `NavMenu.razor.css`, and `Devices.razor.css` are unprefixed and rely on Blazor's per-component scoping. The `::deep` selector on `.nav-link` is preserved (needed because `NavLink` renders an `<a>` not under direct CSS-isolation control).
+3. **`/api/device/{deviceId}/screenshots/latest`** — the tile's thumbnail uses this endpoint. If your routing only exposes `/screenshots/{id}`, either add a `latest` shortcut or change the `<img src>` in `Devices.razor` to use `device.LatestScreenshotAt` to pick the most recent ID. Falls back gracefully to the "NO SCREENSHOT" empty state if not present.
+4. **`Microsoft.AspNetCore.Components.Web` namespace** — `Devices.razor` uses `KeyboardEventArgs`. This was already imported via the existing `_Imports.razor`; no change needed.
+
+## How to apply
+
+```bash
+git checkout -b mission-control-redesign
+# Copy the seven files from pr/src/PlainSight.Server/... into the matching paths
+git add src/PlainSight.Server
+git commit -m "Redesign admin UI as Mission Control"
+git push -u origin mission-control-redesign
+gh pr create --title "Mission Control admin redesign" --body-file PR_DESCRIPTION.md
+```
+
+## Screenshots
+
+See the prototype in `Mission Control.html` (React mock at the same fidelity as the final Blazor output).

--- a/src/PlainSight.Server/Components/Layout/MainLayout.razor
+++ b/src/PlainSight.Server/Components/Layout/MainLayout.razor
@@ -1,4 +1,9 @@
 @inherits LayoutComponentBase
+@using Microsoft.EntityFrameworkCore
+@using PlainSight.Shared.Models
+@using PlainSight.Server.Data
+@inject IDbContextFactory<PlainSightDbContext> DbFactory
+@implements IDisposable
 
 <div class="page">
     <div class="sidebar">
@@ -6,10 +11,40 @@
     </div>
 
     <main>
-        <div class="top-bar px-4">
-            <span class="system-status">
-                <i class="bi bi-circle-fill"></i> System Running
-            </span>
+        <div class="top-bar">
+            <div class="top-bar__left">
+                <div class="sysled">
+                    <span class="led led-pulse"></span>
+                    <div>
+                        <div class="sysled__title">SYSTEM NOMINAL</div>
+                        <div class="sysled__sub">All services healthy · @currentTime UTC</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="top-bar__kpis">
+                <div class="kpi kpi--online">
+                    <div class="kpi__head">
+                        <span class="kpi__dot"></span>
+                        <span class="kpi__label">ACTIVE</span>
+                    </div>
+                    <div class="kpi__value">@onlineCount<span class="kpi__sub">/ @totalCount</span></div>
+                </div>
+                <div class="kpi kpi--warn">
+                    <div class="kpi__head">
+                        <span class="kpi__dot"></span>
+                        <span class="kpi__label">DEGRADED</span>
+                    </div>
+                    <div class="kpi__value">@warnCount<span class="kpi__sub">players</span></div>
+                </div>
+                <div class="kpi kpi--offline">
+                    <div class="kpi__head">
+                        <span class="kpi__dot"></span>
+                        <span class="kpi__label">OFFLINE</span>
+                    </div>
+                    <div class="kpi__value">@offlineCount<span class="kpi__sub">players</span></div>
+                </div>
+            </div>
         </div>
 
         <article class="content px-4">
@@ -23,3 +58,52 @@
     <a href="." class="reload">Reload</a>
     <span class="dismiss">✕</span>
 </div>
+
+@code {
+    private int totalCount;
+    private int onlineCount;
+    private int warnCount;
+    private int offlineCount;
+    private string currentTime = DateTime.UtcNow.ToString("HH:mm:ss");
+    private Timer? refreshTimer;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await RefreshKpisAsync();
+        refreshTimer = new Timer(async _ =>
+        {
+            await InvokeAsync(async () =>
+            {
+                await RefreshKpisAsync();
+                currentTime = DateTime.UtcNow.ToString("HH:mm:ss");
+                StateHasChanged();
+            });
+        }, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
+    }
+
+    private async Task RefreshKpisAsync()
+    {
+        try
+        {
+            using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
+            DateTime now = DateTime.UtcNow;
+            DateTime onlineCutoff = now.AddSeconds(-60);
+            DateTime warnCutoff = now.AddMinutes(-5);
+
+            List<Device> devices = await context.Devices.ToListAsync();
+            totalCount = devices.Count;
+            onlineCount = devices.Count(d => d.LastSeen >= onlineCutoff);
+            warnCount = devices.Count(d => d.LastSeen < onlineCutoff && d.LastSeen >= warnCutoff);
+            offlineCount = devices.Count(d => d.LastSeen < warnCutoff);
+        }
+        catch
+        {
+            // KPIs are best-effort; never let a failure break the layout.
+        }
+    }
+
+    public void Dispose()
+    {
+        refreshTimer?.Dispose();
+    }
+}

--- a/src/PlainSight.Server/Components/Layout/MainLayout.razor.css
+++ b/src/PlainSight.Server/Components/Layout/MainLayout.razor.css
@@ -9,87 +9,185 @@ main {
     flex: 1;
     display: flex;
     flex-direction: column;
-    background-color: #f1f5f9;
+    min-width: 0;
+    background: transparent;
 }
 
 .sidebar {
-    background-color: #0f172a;
+    background: linear-gradient(180deg, #0A1325 0%, #060B17 100%);
+    border-right: 1px solid var(--ps-line);
+    z-index: 5;
 }
 
-/* Top bar */
+/* ── Top bar ─────────────────────────────────────────────────────── */
 .top-bar {
-    background-color: #ffffff;
-    border-bottom: 1px solid #e2e8f0;
-    height: 3rem;
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
     position: sticky;
     top: 0;
     z-index: 10;
-}
-
-.system-status {
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: #16a34a;
     display: flex;
     align-items: center;
-    gap: 0.375rem;
+    gap: 18px;
+    padding: 10px 24px;
+    height: 64px;
+    background: var(--ps-glass-strong);
+    backdrop-filter: blur(16px) saturate(160%);
+    -webkit-backdrop-filter: blur(16px) saturate(160%);
+    border-bottom: 1px solid var(--ps-line);
 }
 
-.system-status .bi-circle-fill {
-    font-size: 0.45rem;
+.top-bar__left { display: flex; align-items: center; }
+
+.sysled { display: flex; align-items: center; gap: 10px; }
+.sysled .led {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--ps-online);
+    box-shadow: 0 0 14px var(--ps-online-glow);
+    color: var(--ps-online);
+    display: inline-block;
+}
+.sysled__title {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    color: var(--ps-online);
+}
+.sysled__sub {
+    font-family: var(--ps-mono);
+    font-size: 10.5px;
+    color: var(--ps-text-3);
+    letter-spacing: 0.04em;
+    margin-top: 1px;
 }
 
-/* Content area */
+.top-bar__kpis {
+    display: flex;
+    align-items: stretch;
+    gap: 10px;
+    margin-left: auto;
+}
+
+.kpi {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 6px 14px;
+    border-radius: 8px;
+    border: 1px solid var(--ps-line);
+    background: rgba(8,14,26,0.6);
+    min-width: 110px;
+}
+.kpi__head { display: flex; align-items: center; gap: 6px; }
+.kpi__dot {
+    width: 6px; height: 6px; border-radius: 50%;
+    box-shadow: 0 0 8px currentColor;
+    display: inline-block;
+}
+.kpi__label { font-size: 9.5px; letter-spacing: 0.14em; font-weight: 700; }
+.kpi__value {
+    font-family: var(--ps-mono);
+    font-size: 18px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    line-height: 1;
+    color: var(--ps-text);
+}
+.kpi__sub {
+    font-family: var(--ps-mono);
+    font-size: 11px;
+    color: var(--ps-text-3);
+    margin-left: 4px;
+    font-weight: 400;
+}
+
+.kpi--online   { border-color: rgba(16,185,129,0.25); }
+.kpi--online .kpi__dot, .kpi--online .kpi__label   { background: var(--ps-online); color: var(--ps-online); }
+.kpi--online .kpi__label { background: transparent; }
+
+.kpi--warn     { border-color: rgba(245,158,11,0.25); }
+.kpi--warn .kpi__dot   { background: var(--ps-warn); }
+.kpi--warn .kpi__label { color: var(--ps-warn); }
+
+.kpi--offline  { border-color: rgba(239,68,68,0.25); }
+.kpi--offline .kpi__dot   { background: var(--ps-offline); }
+.kpi--offline .kpi__label { color: var(--ps-offline); }
+
+/* ── Content area ────────────────────────────────────────────────── */
 .content {
     padding-top: 1.75rem;
     padding-bottom: 2rem;
     flex: 1;
+    min-width: 0;
 }
 
 @media (min-width: 641px) {
     .page {
         flex-direction: row;
     }
-
     .sidebar {
-        width: 220px;
+        width: 248px;
         height: 100vh;
         position: sticky;
         top: 0;
         flex-shrink: 0;
     }
-
     .top-bar, article {
         padding-left: 2rem !important;
         padding-right: 2rem !important;
     }
 }
 
-/* Blazor error toast */
+@media (max-width: 1100px) {
+    .kpi { min-width: 96px; padding: 6px 10px; }
+    .kpi__value { font-size: 16px; }
+    .sysled__sub { display: none; }
+}
+
+@media (max-width: 880px) {
+    .top-bar__kpis { display: none; }
+}
+
+/* Pulse animation */
+@keyframes pulse-led {
+    0%, 100% { transform: scale(1);   opacity: 1;   }
+    50%      { transform: scale(1.6); opacity: 0.4; }
+}
+.led-pulse { position: relative; }
+.led-pulse::after {
+    content: '';
+    position: absolute; inset: -3px;
+    border-radius: 50%;
+    background: currentColor;
+    opacity: 0.3;
+    animation: pulse-led 1.6s ease-out infinite;
+}
+
+/* ── Blazor error toast ──────────────────────────────────────────── */
 #blazor-error-ui {
-    color-scheme: light only;
-    background: #fef2f2;
-    border-top: 1px solid #fecaca;
-    color: #991b1b;
+    color-scheme: dark only;
+    background: var(--ps-offline-dim);
+    border-top: 1px solid rgba(239,68,68,0.4);
+    color: #FCA5A5;
     bottom: 0;
-    box-shadow: 0 -2px 8px rgba(0,0,0,0.08);
+    box-shadow: 0 -2px 16px rgba(0,0,0,0.5);
     box-sizing: border-box;
     display: none;
     left: 0;
-    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+    padding: 0.65rem 1.25rem;
     position: fixed;
     width: 100%;
     z-index: 1000;
-    font-size: 0.875rem;
+    font-size: 13px;
 }
-
 #blazor-error-ui .dismiss {
     cursor: pointer;
     position: absolute;
     right: 0.75rem;
     top: 0.5rem;
-    font-size: 0.875rem;
+    font-size: 14px;
+}
+#blazor-error-ui .reload {
+    color: #FCA5A5;
+    text-decoration: underline;
 }

--- a/src/PlainSight.Server/Components/Layout/NavMenu.razor
+++ b/src/PlainSight.Server/Components/Layout/NavMenu.razor
@@ -1,18 +1,35 @@
 @using Microsoft.AspNetCore.Components.Authorization
 
-<div class="sidebar">
+<div class="sidebar-shell">
     <div class="sidebar-brand">
-        <i class="bi bi-display-fill sidebar-brand-icon"></i>
+        <div class="sidebar-brand-mark">
+            <svg viewBox="0 0 32 32" width="22" height="22" fill="none" aria-hidden="true">
+                <defs>
+                    <linearGradient id="psLogoGrad" x1="0" y1="0" x2="1" y2="1">
+                        <stop offset="0%" stop-color="#22D3EE"/>
+                        <stop offset="100%" stop-color="#3B82F6"/>
+                    </linearGradient>
+                </defs>
+                <rect x="2" y="2" width="28" height="28" rx="7" fill="none" stroke="url(#psLogoGrad)" stroke-width="1.5"/>
+                <circle cx="16" cy="16" r="3.2" fill="#22D3EE"/>
+                <circle cx="16" cy="16" r="7" fill="none" stroke="#22D3EE" stroke-opacity="0.5" stroke-width="1"/>
+                <circle cx="16" cy="16" r="11" fill="none" stroke="#3B82F6" stroke-opacity="0.4" stroke-width="1"/>
+            </svg>
+        </div>
         <div>
             <div class="sidebar-brand-name">PlainSight</div>
-            <div class="sidebar-brand-sub">Digital Signage</div>
+            <div class="sidebar-brand-sub">v2.4.1 · NOC</div>
         </div>
     </div>
 
-    <nav class="nav-menu">
+    <input type="checkbox" title="Navigation menu" class="navbar-toggler" />
+
+    <nav class="nav-scrollable">
+        <div class="nav-section-label">Operations</div>
+
         <div class="nav-item">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <i class="bi bi-speedometer2"></i> Dashboard
+                <i class="bi bi-grid-1x2-fill"></i> Mission Control
             </NavLink>
         </div>
 
@@ -22,7 +39,7 @@
             </NavLink>
         </div>
 
-        <div class="nav-section-title">Library</div>
+        <div class="nav-section-label">Library</div>
 
         <div class="nav-item">
             <NavLink class="nav-link" href="content">
@@ -42,7 +59,7 @@
             </NavLink>
         </div>
 
-        <div class="nav-section-title">Live</div>
+        <div class="nav-section-label">Live</div>
 
         <div class="nav-item">
             <NavLink class="nav-link" href="ndi">
@@ -50,7 +67,7 @@
             </NavLink>
         </div>
 
-        <div class="nav-section-title">System</div>
+        <div class="nav-section-label">System</div>
 
         <div class="nav-item">
             <NavLink class="nav-link" href="versions">
@@ -73,12 +90,13 @@
         <AuthorizeView>
             <Authorized>
                 <div class="nav-footer">
-                    <div class="nav-user-info mb-2 px-3 small text-muted">
-                        <i class="bi bi-person-circle"></i> @context.User.Identity?.Name
+                    <div class="nav-user-info">
+                        <i class="bi bi-person-circle"></i>
+                        <span>@context.User.Identity?.Name</span>
                     </div>
                     <form action="auth/logout" method="post">
                         <AntiforgeryToken />
-                        <button type="submit" class="btn btn-link nav-link text-danger w-100 text-start px-3">
+                        <button type="submit" class="nav-signout">
                             <i class="bi bi-box-arrow-right"></i> Sign Out
                         </button>
                     </form>

--- a/src/PlainSight.Server/Components/Layout/NavMenu.razor.css
+++ b/src/PlainSight.Server/Components/Layout/NavMenu.razor.css
@@ -1,61 +1,79 @@
-.navbar-toggler {
-    appearance: none;
-    cursor: pointer;
-    width: 3.5rem;
-    height: 2.5rem;
-    color: white;
-    position: absolute;
-    top: 0.5rem;
-    right: 1rem;
-    border: 1px solid rgba(255,255,255,0.15);
-    border-radius: 6px;
-    background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255,255,255,0.6%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") no-repeat center/1.5rem transparent;
-}
-
-.navbar-toggler:checked {
-    background-color: rgba(255,255,255,0.1);
+.sidebar-shell {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: 16px 12px 12px;
 }
 
 /* Brand */
 .sidebar-brand {
     display: flex;
     align-items: center;
-    gap: 0.75rem;
-    padding: 1.25rem 1.25rem 1.125rem;
-    border-bottom: 1px solid rgba(255,255,255,0.07);
+    gap: 10px;
+    padding: 4px 6px 14px;
+    margin-bottom: 6px;
+    border-bottom: 1px solid rgba(255,255,255,0.05);
 }
 
-.sidebar-brand-icon {
-    font-size: 1.5rem;
-    color: #38bdf8;
+.sidebar-brand-mark {
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
+    background: rgba(34,211,238,0.06);
+    border: 1px solid var(--ps-line-strong);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 0 18px rgba(34,211,238,0.15) inset;
     flex-shrink: 0;
 }
 
 .sidebar-brand-name {
-    color: #f1f5f9;
-    font-size: 1rem;
-    font-weight: 700;
-    letter-spacing: -0.01em;
+    color: var(--ps-text);
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
     line-height: 1.2;
 }
 
 .sidebar-brand-sub {
-    color: #475569;
-    font-size: 0.65rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    line-height: 1;
+    color: var(--ps-text-3);
+    font-family: var(--ps-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.06em;
+    line-height: 1.2;
+    margin-top: 2px;
+}
+
+/* Mobile toggle */
+.navbar-toggler {
+    appearance: none;
+    cursor: pointer;
+    width: 3rem;
+    height: 2.25rem;
+    color: white;
+    position: absolute;
+    top: 0.75rem;
+    right: 1rem;
+    border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 6px;
+    background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%2834,211,238,0.7%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e") no-repeat center/1.5rem transparent;
+}
+.navbar-toggler:checked {
+    background-color: rgba(34,211,238,0.1);
 }
 
 /* Section labels */
 .nav-section-label {
-    color: #334155;
-    font-size: 0.65rem;
+    color: var(--ps-text-3);
+    font-size: 9.5px;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.1em;
-    padding: 1.1rem 1.25rem 0.35rem;
+    letter-spacing: 0.16em;
+    padding: 1rem 0.75rem 0.4rem;
 }
+
+.nav-section-label:first-of-type { padding-top: 0.5rem; }
 
 /* Nav items */
 .nav-item {
@@ -63,42 +81,87 @@
 }
 
 ::deep .nav-link {
-    color: #64748b;
-    border-radius: 6px;
-    margin: 1px 0.625rem;
-    padding: 0.575rem 0.75rem;
+    color: var(--ps-text-2);
+    border-radius: 7px;
+    margin: 1px 0;
+    padding: 0.5rem 0.75rem;
     display: flex;
     align-items: center;
-    gap: 0.6rem;
-    font-size: 0.875rem;
+    gap: 0.625rem;
+    font-size: 13px;
     font-weight: 500;
     line-height: 1.25;
-    transition: color 0.12s, background-color 0.12s;
+    transition: color 0.12s, background-color 0.12s, border-color 0.12s;
     text-decoration: none;
+    border: 1px solid transparent;
+    position: relative;
 }
 
 ::deep .nav-link:hover {
-    color: #cbd5e1;
-    background-color: rgba(255,255,255,0.05);
+    color: var(--ps-text);
+    background-color: var(--ps-bg-2);
 }
 
 ::deep a.active {
-    color: #38bdf8;
-    background-color: rgba(56,189,248,0.1);
-}
-
-::deep a.active:hover {
-    background-color: rgba(56,189,248,0.15);
-}
-
-::deep .nav-link .bi {
-    font-size: 0.9rem;
-    flex-shrink: 0;
-    opacity: 0.8;
+    color: var(--ps-text);
+    background: linear-gradient(180deg, rgba(34,211,238,0.10), rgba(34,211,238,0.04));
+    border-color: rgba(34,211,238,0.25);
+    box-shadow: inset 2px 0 0 var(--ps-cyan);
 }
 
 ::deep a.active .bi {
+    color: var(--ps-cyan);
     opacity: 1;
+}
+
+::deep .nav-link .bi {
+    font-size: 0.95rem;
+    flex-shrink: 0;
+    opacity: 0.75;
+    width: 16px;
+    text-align: center;
+}
+
+/* Footer */
+.nav-spacer { flex: 1; }
+
+.nav-footer {
+    padding: 12px 6px 4px;
+    border-top: 1px solid var(--ps-line);
+    margin-top: 8px;
+}
+.nav-user-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px;
+    font-size: 12px;
+    color: var(--ps-text-2);
+    margin-bottom: 4px;
+}
+.nav-user-info .bi {
+    color: var(--ps-cyan);
+    font-size: 1rem;
+}
+.nav-signout {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 8px 10px;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    color: #FCA5A5;
+    font-size: 12.5px;
+    font-weight: 500;
+    text-align: left;
+    cursor: pointer;
+    transition: background-color 0.12s, border-color 0.12s;
+}
+.nav-signout:hover {
+    background: var(--ps-offline-dim);
+    border-color: rgba(239,68,68,0.3);
 }
 
 /* Collapsed on mobile */
@@ -107,17 +170,18 @@
 }
 
 .navbar-toggler:checked ~ .nav-scrollable {
-    display: block;
+    display: flex;
+    flex-direction: column;
 }
 
 @media (min-width: 641px) {
     .navbar-toggler {
         display: none;
     }
-
     .nav-scrollable {
-        display: block;
-        height: calc(100vh - 4rem);
+        display: flex;
+        flex-direction: column;
+        height: calc(100vh - 5rem);
         overflow-y: auto;
         padding-bottom: 1rem;
     }

--- a/src/PlainSight.Server/Components/Pages/Devices.razor
+++ b/src/PlainSight.Server/Components/Pages/Devices.razor
@@ -37,58 +37,106 @@ else if (!devices.Any())
 }
 else
 {
-    <div class="table-responsive">
-        <table class="table table-striped table-hover">
-            <thead>
-                <tr>
-                    <th>
+    <div class="ps-toolbar">
+        <div class="ps-toolbar__filters">
+            <button class="ps-filter @(statusFilter == "all" ? "is-active" : "")" @onclick='() => SetFilter("all")'>
+                All <span class="ps-filter__count">@devices.Count</span>
+            </button>
+            <button class="ps-filter ps-filter--online @(statusFilter == "online" ? "is-active" : "")" @onclick='() => SetFilter("online")'>
+                <span class="ps-led"></span> Online <span class="ps-filter__count">@onlineCount</span>
+            </button>
+            <button class="ps-filter ps-filter--warn @(statusFilter == "warn" ? "is-active" : "")" @onclick='() => SetFilter("warn")'>
+                <span class="ps-led"></span> Degraded <span class="ps-filter__count">@warnCount</span>
+            </button>
+            <button class="ps-filter ps-filter--offline @(statusFilter == "offline" ? "is-active" : "")" @onclick='() => SetFilter("offline")'>
+                <span class="ps-led"></span> Offline <span class="ps-filter__count">@offlineCount</span>
+            </button>
+        </div>
+        <div class="ps-toolbar__actions">
+            <button class="btn btn-sm btn-outline-secondary" @onclick="ToggleSelectAllVisible" title="Select all visible">
+                <i class="bi bi-check2-square"></i>
+                @(allVisibleSelected ? "Deselect all" : "Select all")
+            </button>
+            <button class="btn btn-sm btn-primary" @onclick="LoadDevices">
+                <i class="bi bi-arrow-clockwise"></i> Refresh
+            </button>
+        </div>
+    </div>
+
+    <div class="ps-grid @(selectedDeviceIds.Count > 0 ? "ps-grid--bulk-active" : "")">
+        @foreach (Device device in FilteredDevices())
+        {
+            bool isOnline = IsDeviceOnline(device.LastSeen);
+            string statusKey = GetStatusKey(device.LastSeen);
+            bool isSelected = selectedDeviceIds.Contains(device.DeviceId);
+            <div class="ps-tile ps-tile--@statusKey @(isSelected ? "is-selected" : "")">
+                <div class="ps-tile__rail"></div>
+
+                <header class="ps-tile__head">
+                    <label class="ps-tile__check" @onclick:stopPropagation>
                         <input type="checkbox"
-                               class="form-check-input"
-                               checked="@(devices.Count > 0 && selectedDeviceIds.Count == devices.Count)"
-                               @onchange="e => ToggleSelectAll((bool)(e.Value ?? false))"
-                               title="Select all" />
-                    </th>
-                    <th>Status</th>
-                    <th>Device ID</th>
-                    <th>Name</th>
-                    <th>Group</th>
-                    <th>Last Seen</th>
-                    <th>Version</th>
-                    <th>Currently Playing</th>
-                    <th>Live Mode</th>
-                    <th>Screenshot</th>
-                    <th>Actions</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (Device device in devices)
-                {
-                    bool isOnline = IsDeviceOnline(device.LastSeen);
-                    <tr class="@(isOnline ? "" : "table-secondary")">
-                        <td>
-                            <input type="checkbox"
-                                   class="form-check-input"
-                                   checked="@selectedDeviceIds.Contains(device.DeviceId)"
-                                   @onchange="e => ToggleDevice(device.DeviceId, (bool)(e.Value ?? false))" />
-                        </td>
-                        <td>
-                            @if (isOnline)
-                            {
-                                <span class="badge bg-success" title="Online">
-                                    <i class="bi bi-circle-fill"></i> Online
-                                </span>
-                            }
-                            else
-                            {
-                                <span class="badge bg-danger" title="Offline">
-                                    <i class="bi bi-circle-fill"></i> Offline
-                                </span>
-                            }
-                        </td>
-                        <td><code>@device.DeviceId</code></td>
-                        <td>@device.Name</td>
-                        <td>
-                            <select class="form-select form-select-sm"
+                               checked="@isSelected"
+                               @onchange="e => ToggleDevice(device.DeviceId, (bool)(e.Value ?? false))" />
+                    </label>
+                    <div class="ps-tile__ident">
+                        <div class="ps-tile__name" title="@device.Name">@device.Name</div>
+                        <div class="ps-tile__id"><code>@device.DeviceId</code></div>
+                    </div>
+                    <span class="pill pill--@statusKey">
+                        <span class="led @(isOnline ? "led-pulse" : "")"></span>
+                        @GetStatusLabel(statusKey)
+                    </span>
+                </header>
+
+                <div class="ps-tile__screen">
+                    @if (device.LatestScreenshotAt.HasValue)
+                    {
+                        <button class="ps-tile__screen-btn"
+                                @onclick="() => ShowScreenshotHistory(device)"
+                                title="View screenshot history">
+                            <img src="/api/device/@device.DeviceId/screenshots/latest?t=@previewCacheBust"
+                                 alt="" />
+                        </button>
+                    }
+                    else
+                    {
+                        <div class="ps-tile__screen-empty">
+                            <i class="bi bi-image-alt"></i>
+                            <span>NO SCREENSHOT</span>
+                        </div>
+                    }
+                    @if (!isOnline)
+                    {
+                        <div class="ps-tile__nosignal">
+                            <span>NO SIGNAL</span>
+                        </div>
+                    }
+                    @if (IsLiveModeActive(device) && isOnline)
+                    {
+                        <div class="ps-tile__live">
+                            <span class="led led-pulse"></span> LIVE · NDI
+                        </div>
+                    }
+                    <div class="ps-tile__playing" title="@(device.CurrentlyPlaying ?? "")">
+                        @(device.CurrentlyPlaying ?? "—")
+                    </div>
+                </div>
+
+                <div class="ps-tile__telemetry">
+                    <div class="ps-cell">
+                        <div class="ps-cell__label">LAST SEEN</div>
+                        <div class="ps-cell__value" title="@device.LastSeen.ToString("yyyy-MM-dd HH:mm:ss") UTC">
+                            @GetTimeSince(device.LastSeen)
+                        </div>
+                    </div>
+                    <div class="ps-cell">
+                        <div class="ps-cell__label">VERSION</div>
+                        <div class="ps-cell__value mono">@device.CurrentVersion</div>
+                    </div>
+                    <div class="ps-cell">
+                        <div class="ps-cell__label">GROUP</div>
+                        <div class="ps-cell__value">
+                            <select class="ps-cell__select"
                                     value="@device.Group"
                                     @onchange="e => ChangeGroup(device.DeviceId, e.Value?.ToString() ?? device.Group)">
                                 @if (deviceGroups != null)
@@ -103,78 +151,65 @@ else
                                     <option value="@device.Group">@device.Group</option>
                                 }
                             </select>
-                        </td>
-                        <td>
-                            <span title="@device.LastSeen.ToString("yyyy-MM-dd HH:mm:ss")">
-                                @GetTimeSince(device.LastSeen)
-                            </span>
-                        </td>
-                        <td><code>@device.CurrentVersion</code></td>
-                        <td>@(device.CurrentlyPlaying ?? "-")</td>
-                        <td>
-                            <button class="btn btn-sm @(GetLiveModeBadgeClass(device))"
-                                    @onclick="() => OpenLiveModeEditor(device)"
-                                    title="Configure live (NDI) mode">
-                                <i class="bi bi-broadcast"></i> @GetLiveModeLabel(device)
-                            </button>
-                        </td>
-                        <td>
+                        </div>
+                    </div>
+                    <div class="ps-cell">
+                        <div class="ps-cell__label">SCREENSHOT</div>
+                        <div class="ps-cell__value">
                             @if (device.LatestScreenshotAt.HasValue)
                             {
-                                <button class="btn btn-sm btn-outline-secondary"
-                                        @onclick="() => ShowScreenshotHistory(device)"
-                                        title="@device.LatestScreenshotAt.Value.ToString("yyyy-MM-dd HH:mm:ss") UTC">
-                                    <i class="bi bi-image"></i>
-                                    <span>@GetTimeSince(device.LatestScreenshotAt.Value)</span>
-                                </button>
+                                @GetTimeSince(device.LatestScreenshotAt.Value)
                             }
                             else
                             {
                                 <span class="text-muted">—</span>
                             }
-                        </td>
-                        <td>
-                            <button class="btn btn-sm btn-outline-primary"
-                                    @onclick="() => RequestScreenshot(device.DeviceId)"
-                                    disabled="@(!isOnline || requestingScreenshot.Contains(device.DeviceId))">
-                                @if (requestingScreenshot.Contains(device.DeviceId))
-                                {
-                                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                                    <span>Requesting...</span>
-                                }
-                                else
-                                {
-                                    <i class="bi bi-camera"></i>
-                                    <span>Screenshot</span>
-                                }
-                            </button>
-                            <button class="btn btn-sm btn-outline-warning ms-1"
-                                    @onclick="() => ResetApiKey(device.DeviceId)"
-                                    disabled="@resettingApiKey.Contains(device.DeviceId)"
-                                    title="Clear stored API key; device will re-register on next heartbeat">
-                                @if (resettingApiKey.Contains(device.DeviceId))
-                                {
-                                    <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                                    <span>Resetting...</span>
-                                }
-                                else
-                                {
-                                    <i class="bi bi-key"></i>
-                                    <span>Reset Key</span>
-                                }
-                            </button>
-                        </td>
-                    </tr>
-                }
-            </tbody>
-        </table>
+                        </div>
+                    </div>
+                </div>
+
+                <footer class="ps-tile__actions">
+                    <button class="ps-action"
+                            @onclick="() => RequestScreenshot(device.DeviceId)"
+                            disabled="@(!isOnline || requestingScreenshot.Contains(device.DeviceId))"
+                            title="Capture screenshot">
+                        @if (requestingScreenshot.Contains(device.DeviceId))
+                        {
+                            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                        }
+                        else
+                        {
+                            <i class="bi bi-camera"></i>
+                        }
+                        <span>Capture</span>
+                    </button>
+                    <button class="ps-action"
+                            @onclick="() => OpenLiveModeEditor(device)"
+                            title="Configure live (NDI) mode">
+                        <i class="bi bi-broadcast"></i>
+                        <span>@GetLiveModeLabel(device)</span>
+                    </button>
+                    <button class="ps-action ps-action--warn"
+                            @onclick="() => ResetApiKey(device.DeviceId)"
+                            disabled="@resettingApiKey.Contains(device.DeviceId)"
+                            title="Reset API key">
+                        @if (resettingApiKey.Contains(device.DeviceId))
+                        {
+                            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                        }
+                        else
+                        {
+                            <i class="bi bi-key"></i>
+                        }
+                        <span>Reset Key</span>
+                    </button>
+                </footer>
+            </div>
+        }
     </div>
 
-    <div class="mt-3 @(selectedDeviceIds.Count > 0 ? "mb-5 pb-4" : "")">
-        <button class="btn btn-primary" @onclick="LoadDevices">
-            <i class="bi bi-arrow-clockwise"></i> Refresh
-        </button>
-        <span class="ms-2 text-muted">Auto-refreshing every 5 seconds</span>
+    <div class="ps-grid-foot">
+        <span class="text-muted"><i class="bi bi-arrow-clockwise"></i> Auto-refreshing every 5 seconds</span>
     </div>
 }
 
@@ -185,7 +220,7 @@ else
          role="dialog"
          aria-modal="true"
          aria-labelledby="history-modal-title"
-         style="background:rgba(0,0,0,0.5);"
+         style="background:rgba(4,8,14,0.7);"
          @onclick="CloseHistory"
          @onkeydown="HandleModalKeyDown">
         <div class="modal-dialog modal-xl modal-dialog-centered" @onclick:stopPropagation="true">
@@ -222,8 +257,8 @@ else
                         <div class="d-flex flex-wrap gap-2">
                             @foreach (DeviceScreenshotDto shot in screenshotHistory)
                             {
-                                bool isSelected = selectedScreenshot?.Id == shot.Id;
-                                <button class="btn p-1 @(isSelected ? "border border-primary border-2" : "border")"
+                                bool isSelectedShot = selectedScreenshot?.Id == shot.Id;
+                                <button class="btn p-1 @(isSelectedShot ? "border border-info border-2" : "border")"
                                         @onclick="() => SelectScreenshot(shot)"
                                         title="@shot.CapturedAt.ToString("yyyy-MM-dd HH:mm:ss") UTC">
                                     <img src="@shot.Url?t=@previewCacheBust"
@@ -249,7 +284,7 @@ else
          role="dialog"
          aria-modal="true"
          aria-labelledby="live-mode-modal-title"
-         style="background:rgba(0,0,0,0.5);"
+         style="background:rgba(4,8,14,0.7);"
          @onclick="CloseLiveModeEditor">
         <div class="modal-dialog modal-dialog-centered" @onclick:stopPropagation="true">
             <div class="modal-content">
@@ -414,6 +449,56 @@ else
     private bool isBulkAssigningVersion;
     private string? bulkResultMessage;
     private bool bulkResultIsSuccess;
+    private string statusFilter = "all";
+
+    private int onlineCount => devices?.Count(d => GetStatusKey(d.LastSeen) == "online") ?? 0;
+    private int warnCount => devices?.Count(d => GetStatusKey(d.LastSeen) == "warn") ?? 0;
+    private int offlineCount => devices?.Count(d => GetStatusKey(d.LastSeen) == "offline") ?? 0;
+
+    private bool allVisibleSelected
+    {
+        get
+        {
+            List<Device> visible = FilteredDevices().ToList();
+            return visible.Count > 0 && visible.All(d => selectedDeviceIds.Contains(d.DeviceId));
+        }
+    }
+
+    private IEnumerable<Device> FilteredDevices()
+    {
+        if (devices == null) return Enumerable.Empty<Device>();
+        return statusFilter switch
+        {
+            "online"  => devices.Where(d => GetStatusKey(d.LastSeen) == "online"),
+            "warn"    => devices.Where(d => GetStatusKey(d.LastSeen) == "warn"),
+            "offline" => devices.Where(d => GetStatusKey(d.LastSeen) == "offline"),
+            _         => devices
+        };
+    }
+
+    private void SetFilter(string key) => statusFilter = key;
+
+    private string GetStatusKey(DateTime lastSeen)
+    {
+        double secs = (DateTime.UtcNow - lastSeen).TotalSeconds;
+        if (secs < 60) return "online";
+        if (secs < 300) return "warn";
+        return "offline";
+    }
+
+    private string GetStatusLabel(string key) => key switch
+    {
+        "online"  => "ONLINE",
+        "warn"    => "DEGRADED",
+        _         => "OFFLINE"
+    };
+
+    private bool IsLiveModeActive(Device device)
+    {
+        if (device.LiveModeOverride == true) return true;
+        if (device.LiveModeOverride == false) return false;
+        return device.NdiAutoSwitch && device.AssignedNdiSourceId.HasValue;
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -466,14 +551,6 @@ else
         }
     }
 
-    private string GetLiveModeBadgeClass(Device device)
-    {
-        if (device.LiveModeOverride == true) return "btn-danger";
-        if (device.LiveModeOverride == false) return "btn-outline-secondary";
-        if (device.NdiAutoSwitch && device.AssignedNdiSourceId.HasValue) return "btn-warning";
-        return "btn-outline-secondary";
-    }
-
     private string GetLiveModeLabel(Device device)
     {
         if (device.LiveModeOverride == true) return "Forced ON";
@@ -497,28 +574,20 @@ else
         StateHasChanged();
     }
 
-    private void CloseLiveModeEditor()
-    {
-        liveModeDevice = null;
-    }
+    private void CloseLiveModeEditor() => liveModeDevice = null;
 
     private async Task SaveLiveMode()
     {
-        if (liveModeDevice == null)
-            return;
-
+        if (liveModeDevice == null) return;
         isSavingLiveMode = true;
         try
         {
             using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
             Device? device = await context.Devices.FirstOrDefaultAsync(d => d.DeviceId == liveModeDevice.DeviceId);
-            if (device == null)
-                return;
+            if (device == null) return;
 
             device.NdiAutoSwitch = liveModeAutoSwitch;
-            device.AssignedNdiSourceId = int.TryParse(liveModeSourceId, out int parsedSourceId)
-                ? parsedSourceId
-                : null;
+            device.AssignedNdiSourceId = int.TryParse(liveModeSourceId, out int parsedSourceId) ? parsedSourceId : null;
             device.LiveModeOverride = liveModeOverrideValue switch
             {
                 "on" => true,
@@ -546,9 +615,7 @@ else
         try
         {
             using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
-            deviceGroups = await context.DeviceGroups
-                .OrderBy(g => g.Name)
-                .ToListAsync();
+            deviceGroups = await context.DeviceGroups.OrderBy(g => g.Name).ToListAsync();
         }
         catch (Exception ex)
         {
@@ -562,9 +629,7 @@ else
         try
         {
             using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
-            playerVersions = await context.PlayerVersions
-                .OrderByDescending(v => v.VersionNumber)
-                .ToListAsync();
+            playerVersions = await context.PlayerVersions.OrderByDescending(v => v.VersionNumber).ToListAsync();
         }
         catch (Exception ex)
         {
@@ -608,8 +673,7 @@ else
                     Logger.LogInformation("Screenshot requested for device {DeviceId} via {CallbackUrl}", deviceId, device.CallbackUrl);
                     await LoadDevices();
                     Device? updated = devices?.FirstOrDefault(d => d.DeviceId == deviceId);
-                    if (updated != null)
-                        await ShowScreenshotHistory(updated);
+                    if (updated != null) await ShowScreenshotHistory(updated);
                 }
             }
         }
@@ -657,34 +721,31 @@ else
         }
     }
 
-    private void ToggleSelectAll(bool value)
+    private void ToggleSelectAllVisible()
     {
-        selectedDeviceIds.Clear();
-        if (value && devices != null)
+        List<Device> visible = FilteredDevices().ToList();
+        if (visible.Count == 0) return;
+        if (visible.All(d => selectedDeviceIds.Contains(d.DeviceId)))
         {
-            foreach (Device device in devices)
-                selectedDeviceIds.Add(device.DeviceId);
+            foreach (Device d in visible) selectedDeviceIds.Remove(d.DeviceId);
+        }
+        else
+        {
+            foreach (Device d in visible) selectedDeviceIds.Add(d.DeviceId);
         }
     }
 
     private void ToggleDevice(string deviceId, bool value)
     {
-        if (value)
-            selectedDeviceIds.Add(deviceId);
-        else
-            selectedDeviceIds.Remove(deviceId);
+        if (value) selectedDeviceIds.Add(deviceId);
+        else       selectedDeviceIds.Remove(deviceId);
     }
 
-    private void ClearSelection()
-    {
-        selectedDeviceIds.Clear();
-    }
+    private void ClearSelection() => selectedDeviceIds.Clear();
 
     private async Task BulkScreenshot()
     {
-        if (selectedDeviceIds.Count == 0)
-            return;
-
+        if (selectedDeviceIds.Count == 0) return;
         isBulkScreenshotting = true;
         try
         {
@@ -717,9 +778,7 @@ else
 
     private async Task BulkMoveGroup()
     {
-        if (selectedDeviceIds.Count == 0 || string.IsNullOrEmpty(bulkGroupSelection))
-            return;
-
+        if (selectedDeviceIds.Count == 0 || string.IsNullOrEmpty(bulkGroupSelection)) return;
         isBulkMovingGroup = true;
         try
         {
@@ -728,11 +787,7 @@ else
                 .Where(d => selectedDeviceIds.Contains(d.DeviceId))
                 .ToListAsync();
 
-            foreach (Device d in targetDevices)
-            {
-                d.Group = bulkGroupSelection;
-            }
-
+            foreach (Device d in targetDevices) d.Group = bulkGroupSelection;
             await context.SaveChangesAsync();
 
             bulkResultMessage = $"Moved {targetDevices.Count} device(s) to group '{bulkGroupSelection}'.";
@@ -756,9 +811,7 @@ else
 
     private async Task BulkAssignVersion()
     {
-        if (string.IsNullOrEmpty(bulkVersionGroup) || string.IsNullOrEmpty(bulkVersionSelection))
-            return;
-
+        if (string.IsNullOrEmpty(bulkVersionGroup) || string.IsNullOrEmpty(bulkVersionSelection)) return;
         isBulkAssigningVersion = true;
         try
         {
@@ -800,10 +853,7 @@ else
         }
     }
 
-    private void DismissBulkResult()
-    {
-        bulkResultMessage = null;
-    }
+    private void DismissBulkResult() => bulkResultMessage = null;
 
     private async Task ShowScreenshotHistory(Device device)
     {
@@ -826,8 +876,7 @@ else
                     Url = $"/api/device/{device.DeviceId}/screenshots/{s.Id}"
                 })
                 .ToListAsync();
-            if (screenshotHistory.Count > 0)
-                selectedScreenshot = screenshotHistory[0];
+            if (screenshotHistory.Count > 0) selectedScreenshot = screenshotHistory[0];
         }
         catch (Exception ex)
         {
@@ -853,31 +902,19 @@ else
 
     private void HandleModalKeyDown(KeyboardEventArgs e)
     {
-        if (e.Key == "Escape")
-            CloseHistory();
+        if (e.Key == "Escape") CloseHistory();
     }
 
-    private bool IsDeviceOnline(DateTime lastSeen)
-    {
-        return (DateTime.UtcNow - lastSeen).TotalSeconds < 60;
-    }
+    private bool IsDeviceOnline(DateTime lastSeen) => (DateTime.UtcNow - lastSeen).TotalSeconds < 60;
 
     private string GetTimeSince(DateTime dateTime)
     {
         TimeSpan timeSpan = DateTime.UtcNow - dateTime;
-
-        if (timeSpan.TotalSeconds < 60)
-            return $"{(int)timeSpan.TotalSeconds}s ago";
-        if (timeSpan.TotalMinutes < 60)
-            return $"{(int)timeSpan.TotalMinutes}m ago";
-        if (timeSpan.TotalHours < 24)
-            return $"{(int)timeSpan.TotalHours}h ago";
-
+        if (timeSpan.TotalSeconds < 60) return $"{(int)timeSpan.TotalSeconds}s ago";
+        if (timeSpan.TotalMinutes < 60) return $"{(int)timeSpan.TotalMinutes}m ago";
+        if (timeSpan.TotalHours < 24)   return $"{(int)timeSpan.TotalHours}h ago";
         return $"{(int)timeSpan.TotalDays}d ago";
     }
 
-    public void Dispose()
-    {
-        refreshTimer?.Dispose();
-    }
+    public void Dispose() => refreshTimer?.Dispose();
 }

--- a/src/PlainSight.Server/Components/Pages/Devices.razor.css
+++ b/src/PlainSight.Server/Components/Pages/Devices.razor.css
@@ -1,41 +1,381 @@
+/* ─────────────────────────────────────────────────────────────────
+   Devices page — tile grid + filter toolbar + bulk action bar
+   ───────────────────────────────────────────────────────────────── */
+
+/* ── Filter toolbar ─────────────────────────────────────────────── */
+.ps-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 10px 14px;
+    margin-bottom: 18px;
+    background: var(--ps-glass);
+    border: 1px solid var(--ps-line);
+    border-radius: var(--ps-radius);
+    backdrop-filter: blur(8px);
+    flex-wrap: wrap;
+}
+.ps-toolbar__filters { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.ps-toolbar__actions { display: flex; align-items: center; gap: 8px; }
+
+.ps-filter {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    height: 30px;
+    background: transparent;
+    border: 1px solid var(--ps-line);
+    border-radius: 999px;
+    color: var(--ps-text-2);
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    transition: all 0.12s;
+}
+.ps-filter:hover { background: var(--ps-bg-2); color: var(--ps-text); border-color: var(--ps-line-strong); }
+.ps-filter.is-active { background: var(--ps-bg-3); color: var(--ps-text); border-color: var(--ps-line-strong); }
+
+.ps-filter__count {
+    font-family: var(--ps-mono);
+    font-size: 11px;
+    background: rgba(0,0,0,0.3);
+    color: var(--ps-text-2);
+    padding: 1px 6px;
+    border-radius: 999px;
+    min-width: 22px;
+    text-align: center;
+}
+
+.ps-led { width: 7px; height: 7px; border-radius: 50%; background: var(--ps-text-3); display: inline-block; }
+.ps-filter--online .ps-led  { background: var(--ps-online);  box-shadow: 0 0 6px var(--ps-online-glow); }
+.ps-filter--warn   .ps-led  { background: var(--ps-warn);    box-shadow: 0 0 6px var(--ps-warn-glow); }
+.ps-filter--offline .ps-led { background: var(--ps-offline); box-shadow: 0 0 6px var(--ps-offline-glow); }
+
+.ps-filter--online.is-active   { color: var(--ps-online);  border-color: rgba(16,185,129,0.4); background: var(--ps-online-dim); }
+.ps-filter--warn.is-active     { color: var(--ps-warn);    border-color: rgba(245,158,11,0.4); background: var(--ps-warn-dim); }
+.ps-filter--offline.is-active  { color: var(--ps-offline); border-color: rgba(239,68,68,0.4); background: var(--ps-offline-dim); }
+
+/* ── Grid ───────────────────────────────────────────────────────── */
+.ps-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: 14px;
+}
+.ps-grid--bulk-active { padding-bottom: 96px; }
+
+.ps-grid-foot {
+    display: flex;
+    justify-content: center;
+    margin-top: 24px;
+    padding: 12px;
+    font-size: 11.5px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+.ps-grid-foot .bi { margin-right: 6px; color: var(--ps-cyan); }
+
+/* ── Tile ───────────────────────────────────────────────────────── */
+.ps-tile {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    background: linear-gradient(180deg, rgba(20,33,58,0.85), rgba(15,26,46,0.85));
+    border: 1px solid var(--ps-line);
+    border-radius: var(--ps-radius);
+    overflow: hidden;
+    transition: border-color 0.15s, transform 0.15s, box-shadow 0.15s;
+    isolation: isolate;
+}
+.ps-tile:hover {
+    border-color: var(--ps-line-strong);
+    transform: translateY(-1px);
+    box-shadow: 0 8px 30px rgba(0,0,0,0.35);
+}
+.ps-tile.is-selected {
+    border-color: var(--ps-cyan);
+    box-shadow: 0 0 0 1px var(--ps-cyan-dim), 0 8px 30px rgba(0,0,0,0.35);
+}
+
+.ps-tile__rail {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 3px;
+    background: var(--ps-text-3);
+}
+.ps-tile--online  .ps-tile__rail { background: var(--ps-online);  box-shadow: 0 0 14px var(--ps-online-glow); }
+.ps-tile--warn    .ps-tile__rail { background: var(--ps-warn);    box-shadow: 0 0 14px var(--ps-warn-glow); }
+.ps-tile--offline .ps-tile__rail { background: var(--ps-offline); box-shadow: 0 0 14px var(--ps-offline-glow); }
+
+/* Head */
+.ps-tile__head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 14px 10px 18px;
+}
+.ps-tile__check {
+    display: flex;
+    align-items: center;
+}
+.ps-tile__check input {
+    width: 16px; height: 16px;
+    accent-color: var(--ps-cyan);
+    background: var(--ps-bg-1);
+    cursor: pointer;
+}
+.ps-tile__ident { flex: 1; min-width: 0; }
+.ps-tile__name {
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--ps-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.ps-tile__id {
+    font-family: var(--ps-mono);
+    font-size: 10.5px;
+    color: var(--ps-text-3);
+    margin-top: 1px;
+}
+.ps-tile__id code { color: var(--ps-text-mono); font-size: inherit; }
+
+/* Screen / thumbnail */
+.ps-tile__screen {
+    position: relative;
+    aspect-ratio: 16 / 9;
+    margin: 0 14px;
+    border-radius: 6px;
+    background: #000;
+    overflow: hidden;
+    border: 1px solid var(--ps-line);
+}
+.ps-tile__screen-btn {
+    display: block;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+}
+.ps-tile__screen-btn img {
+    width: 100%; height: 100%;
+    object-fit: cover;
+    display: block;
+}
+.ps-tile__screen-empty {
+    width: 100%; height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    color: var(--ps-text-3);
+    font-size: 10.5px;
+    letter-spacing: 0.12em;
+    background:
+        repeating-linear-gradient(45deg, rgba(255,255,255,0.02) 0 8px, transparent 8px 16px),
+        var(--ps-bg-1);
+}
+.ps-tile__screen-empty .bi { font-size: 1.5rem; opacity: 0.5; }
+
+.ps-tile__nosignal {
+    position: absolute; inset: 0;
+    display: flex; align-items: center; justify-content: center;
+    color: var(--ps-offline);
+    font-family: var(--ps-mono);
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    background:
+        repeating-linear-gradient(135deg, rgba(239,68,68,0.08) 0 12px, rgba(0,0,0,0.6) 12px 24px);
+    text-shadow: 0 0 12px rgba(239,68,68,0.6);
+}
+.ps-tile__nosignal span {
+    border: 1px solid rgba(239,68,68,0.4);
+    padding: 4px 12px;
+    border-radius: 4px;
+    background: rgba(0,0,0,0.5);
+}
+
+.ps-tile__live {
+    position: absolute;
+    top: 8px; left: 8px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 8px;
+    background: rgba(0,0,0,0.7);
+    border: 1px solid rgba(239,68,68,0.5);
+    border-radius: 4px;
+    color: var(--ps-offline);
+    font-family: var(--ps-mono);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+}
+.ps-tile__live .led {
+    width: 6px; height: 6px; border-radius: 50%;
+    background: var(--ps-offline);
+    box-shadow: 0 0 6px var(--ps-offline-glow);
+    color: var(--ps-offline);
+}
+
+.ps-tile__playing {
+    position: absolute;
+    bottom: 0; left: 0; right: 0;
+    padding: 6px 10px;
+    background: linear-gradient(180deg, transparent, rgba(0,0,0,0.8));
+    color: var(--ps-text);
+    font-size: 11px;
+    line-height: 1.3;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Telemetry grid */
+.ps-tile__telemetry {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1px;
+    margin: 14px;
+    background: var(--ps-line);
+    border: 1px solid var(--ps-line);
+    border-radius: 6px;
+    overflow: hidden;
+}
+.ps-cell {
+    background: var(--ps-bg-1);
+    padding: 8px 10px;
+    min-width: 0;
+}
+.ps-cell__label {
+    font-size: 9.5px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    color: var(--ps-text-3);
+    margin-bottom: 3px;
+}
+.ps-cell__value {
+    font-size: 12px;
+    color: var(--ps-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.ps-cell__value.mono { font-family: var(--ps-mono); color: var(--ps-text-mono); font-size: 11.5px; }
+.ps-cell__select {
+    width: 100%;
+    background-color: transparent;
+    border: 0;
+    color: var(--ps-text);
+    font-size: 12px;
+    font-family: inherit;
+    cursor: pointer;
+    padding: 2px 18px 2px 0;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%2322D3EE' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 2px center;
+    background-size: 10px 10px;
+}
+.ps-cell__select:focus { outline: none; color: var(--ps-cyan); }
+.ps-cell__select option { background: var(--ps-bg-2); color: var(--ps-text); }
+
+/* Actions */
+.ps-tile__actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 1px;
+    margin-top: auto;
+    background: var(--ps-line);
+    border-top: 1px solid var(--ps-line);
+}
+.ps-action {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 10px 6px;
+    background: var(--ps-bg-1);
+    border: 0;
+    color: var(--ps-text-2);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    transition: background-color 0.12s, color 0.12s;
+}
+.ps-action:hover:not(:disabled) {
+    background: var(--ps-bg-3);
+    color: var(--ps-cyan);
+}
+.ps-action:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+.ps-action .bi { font-size: 13px; }
+.ps-action--warn:hover:not(:disabled) { color: var(--ps-warn); }
+
+/* ── Bulk action bar ───────────────────────────────────────────── */
 .bulk-action-bar {
     position: fixed;
     bottom: 0;
     left: 0;
     right: 0;
     z-index: 1050;
-    background-color: var(--bs-body-bg, #fff);
-    border-top: 2px solid var(--bs-primary, #0d6efd);
-    box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.12);
-    padding: 0.625rem 1.5rem;
+    background: var(--ps-glass-strong);
+    backdrop-filter: blur(20px) saturate(160%);
+    -webkit-backdrop-filter: blur(20px) saturate(160%);
+    border-top: 1px solid var(--ps-cyan);
+    box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.5), 0 -1px 0 var(--ps-cyan-dim);
+    padding: 12px 24px;
     display: flex;
     align-items: center;
-    gap: 0.75rem;
+    gap: 16px;
     flex-wrap: wrap;
+    color: var(--ps-text);
 }
 
 .bulk-action-bar__info {
     display: flex;
     align-items: center;
+    gap: 8px;
     white-space: nowrap;
-    font-size: 0.9rem;
+    font-size: 13px;
+    color: var(--ps-text);
+}
+.bulk-action-bar__info strong {
+    color: var(--ps-cyan);
+    font-family: var(--ps-mono);
+    font-weight: 600;
 }
 
 .bulk-action-bar__actions {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 8px;
     flex-wrap: wrap;
     flex: 1;
 }
 
 .bulk-action-bar__sep {
-    color: var(--bs-secondary, #6c757d);
-    font-size: 1rem;
+    color: var(--ps-line-strong);
+    font-size: 14px;
     padding: 0 0.25rem;
 }
 
 .bulk-action-bar__select {
-    min-width: 140px;
+    min-width: 150px;
     width: auto;
+}
+
+@media (max-width: 880px) {
+    .ps-tile__actions { grid-template-columns: 1fr 1fr; }
+    .ps-tile__actions .ps-action:last-child { grid-column: 1 / -1; }
 }

--- a/src/PlainSight.Server/wwwroot/app.css
+++ b/src/PlainSight.Server/wwwroot/app.css
@@ -1,262 +1,644 @@
-/* ── Global tokens ─────────────────────────────────────────────── */
+/* ─────────────────────────────────────────────────────────────────
+   PlainSight — Mission Control aesthetic
+   Industrial dark mode, glassmorphism touches, status-at-a-glance.
+   Replaces wwwroot/app.css
+   ───────────────────────────────────────────────────────────────── */
+
 :root {
-    --ps-accent:       #0ea5e9;
-    --ps-accent-dark:  #0284c7;
-    --ps-accent-light: rgba(14,165,233,0.12);
-    --ps-sidebar:      #0f172a;
-    --ps-bg:           #f1f5f9;
-    --ps-surface:      #ffffff;
-    --ps-border:       #e2e8f0;
-    --ps-text:         #0f172a;
-    --ps-text-muted:   #64748b;
-    --ps-success:      #16a34a;
-    --ps-danger:       #dc2626;
-    --ps-warning:      #d97706;
+    /* Surface scale — deep industrial blues */
+    --ps-bg-0:        #06090F;
+    --ps-bg-1:        #0A111E;
+    --ps-bg-2:        #0F1A2E;
+    --ps-bg-3:        #14213A;
+    --ps-bg-4:        #1A2A47;
+
+    /* Glass */
+    --ps-glass:       rgba(18, 30, 54, 0.55);
+    --ps-glass-strong:rgba(22, 36, 64, 0.78);
+    --ps-glass-edge:  rgba(86, 138, 226, 0.18);
+
+    /* Borders */
+    --ps-line:        #1B2942;
+    --ps-line-strong: #243556;
+    --ps-line-glow:   rgba(34, 211, 238, 0.25);
+
+    /* Text */
+    --ps-text:        #E6EDF7;
+    --ps-text-2:      #A5B3CC;
+    --ps-text-3:      #6B7B99;
+    --ps-text-mono:   #9CC6FF;
+
+    /* Accents */
+    --ps-cyan:        #22D3EE;
+    --ps-cyan-dim:    rgba(34, 211, 238, 0.14);
+    --ps-blue:        #3B82F6;
+    --ps-blue-dim:    rgba(59, 130, 246, 0.16);
+
+    /* Status — vibrant with halo variants */
+    --ps-online:      #10B981;
+    --ps-online-dim:  rgba(16, 185, 129, 0.16);
+    --ps-online-glow: rgba(16, 185, 129, 0.55);
+
+    --ps-warn:        #F59E0B;
+    --ps-warn-dim:    rgba(245, 158, 11, 0.16);
+    --ps-warn-glow:   rgba(245, 158, 11, 0.55);
+
+    --ps-offline:     #EF4444;
+    --ps-offline-dim: rgba(239, 68, 68, 0.16);
+    --ps-offline-glow:rgba(239, 68, 68, 0.55);
+
+    /* Legacy aliases (used in existing code) */
+    --ps-accent:       var(--ps-cyan);
+    --ps-accent-dark:  #0EA5C1;
+    --ps-accent-light: var(--ps-cyan-dim);
+    --ps-sidebar:      var(--ps-bg-2);
+    --ps-bg:           var(--ps-bg-1);
+    --ps-surface:      var(--ps-bg-2);
+    --ps-border:       var(--ps-line);
+    --ps-text-muted:   var(--ps-text-3);
+    --ps-success:      var(--ps-online);
+    --ps-danger:       var(--ps-offline);
+    --ps-warning:      var(--ps-warn);
+
+    /* Type */
+    --ps-font:        'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+    --ps-mono:        'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
+
+    /* Geometry */
+    --ps-radius-sm:   6px;
+    --ps-radius:      10px;
+    --ps-radius-lg:   14px;
+
+    /* Bootstrap overrides for dark theme */
+    --bs-body-bg:     var(--ps-bg-1);
+    --bs-body-color:  var(--ps-text);
+    --bs-border-color:var(--ps-line);
 }
 
 /* ── Base ──────────────────────────────────────────────────────── */
 html, body {
-    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
-    font-size: 15px;
+    font-family: var(--ps-font);
+    font-size: 14px;
     color: var(--ps-text);
-    background-color: var(--ps-bg);
+    background-color: var(--ps-bg-0);
     -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+}
+
+body {
+    background:
+        radial-gradient(1200px 700px at 12% -10%, rgba(34,211,238,0.07), transparent 60%),
+        radial-gradient(900px 600px at 95% 0%, rgba(59,130,246,0.06), transparent 55%),
+        linear-gradient(180deg, #08101F 0%, #060A12 100%);
+    background-attachment: fixed;
+    min-height: 100vh;
 }
 
 a {
-    color: var(--ps-accent);
+    color: var(--ps-cyan);
     text-decoration: none;
 }
-
-a:hover {
-    color: var(--ps-accent-dark);
-    text-decoration: underline;
-}
+a:hover { color: #67E8F9; text-decoration: underline; }
 
 h1 {
-    font-size: 1.5rem;
-    font-weight: 700;
-    letter-spacing: -0.02em;
+    font-size: 22px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
     color: var(--ps-text);
-    margin-bottom: 0.25rem;
+    margin-bottom: 4px;
 }
-
 h1:focus { outline: none; }
 
-/* ── Bootstrap overrides ───────────────────────────────────────── */
-
-/* Primary color → accent */
-.btn-primary {
-    background-color: var(--ps-accent);
-    border-color: var(--ps-accent);
-    color: #fff;
-    font-weight: 500;
-}
-
-.btn-primary:hover, .btn-primary:focus {
-    background-color: var(--ps-accent-dark);
-    border-color: var(--ps-accent-dark);
-    color: #fff;
-}
-
-.btn {
+/* Scrollbars */
+*::-webkit-scrollbar { width: 10px; height: 10px; }
+*::-webkit-scrollbar-track { background: transparent; }
+*::-webkit-scrollbar-thumb {
+    background: var(--ps-line);
     border-radius: 6px;
-    font-size: 0.875rem;
+    border: 2px solid var(--ps-bg-1);
+}
+*::-webkit-scrollbar-thumb:hover { background: var(--ps-line-strong); }
+
+code, pre, .mono {
+    font-family: var(--ps-mono);
+    color: var(--ps-text-mono);
+    background: transparent;
+    font-size: 12px;
+}
+
+/* ── Bootstrap overrides for dark theme ────────────────────────── */
+.btn {
+    border-radius: var(--ps-radius-sm);
+    font-size: 12.5px;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    padding: 0.4rem 0.875rem;
+}
+.btn-primary {
+    background: linear-gradient(180deg, #2A6FE6, #1E58C7);
+    border-color: #4D8AF0;
+    color: #fff;
+    box-shadow: 0 1px 0 rgba(255,255,255,0.18) inset, 0 4px 12px rgba(30,88,199,0.3);
+}
+.btn-primary:hover, .btn-primary:focus {
+    background: linear-gradient(180deg, #3B7DF0, #2A6FE6);
+    border-color: #67A0FF;
+    color: #fff;
+}
+.btn-secondary {
+    background: var(--ps-bg-3);
+    border-color: var(--ps-line-strong);
+    color: var(--ps-text);
+}
+.btn-secondary:hover { background: var(--ps-bg-4); border-color: var(--ps-cyan); color: var(--ps-text); }
+
+.btn-success { background: var(--ps-online); border-color: var(--ps-online); color: #022414; }
+.btn-warning { background: var(--ps-warn); border-color: var(--ps-warn); color: #2A1700; }
+.btn-danger  { background: var(--ps-offline); border-color: var(--ps-offline); color: #fff; }
+
+/* Outline buttons — give them a tinted fill so they're legible on dark surfaces.
+   Pure-transparent outlines disappear against #0F1A2E, so we use a soft fill
+   plus a stronger border. They still read as "secondary" vs the solid primary. */
+.btn-outline-primary {
+    color: var(--ps-cyan);
+    border-color: rgba(34,211,238,0.5);
+    background: var(--ps-cyan-dim);
+}
+.btn-outline-primary:hover, .btn-outline-primary:focus {
+    background: rgba(34,211,238,0.22);
+    border-color: var(--ps-cyan);
+    color: #A5F3FC;
+}
+
+.btn-outline-secondary {
+    color: var(--ps-text);
+    border-color: var(--ps-line-strong);
+    background: var(--ps-bg-3);
+}
+.btn-outline-secondary:hover, .btn-outline-secondary:focus {
+    background: var(--ps-bg-4);
+    color: var(--ps-text);
+    border-color: var(--ps-cyan);
+}
+
+.btn-outline-warning {
+    color: var(--ps-warn);
+    border-color: rgba(245,158,11,0.5);
+    background: var(--ps-warn-dim);
+}
+.btn-outline-warning:hover, .btn-outline-warning:focus {
+    background: rgba(245,158,11,0.22);
+    border-color: var(--ps-warn);
+    color: #FCD34D;
+}
+
+.btn-outline-danger {
+    color: var(--ps-offline);
+    border-color: rgba(239,68,68,0.5);
+    background: var(--ps-offline-dim);
+}
+.btn-outline-danger:hover, .btn-outline-danger:focus {
+    background: rgba(239,68,68,0.22);
+    border-color: var(--ps-offline);
+    color: #FCA5A5;
+}
+
+.btn-outline-success {
+    color: var(--ps-online);
+    border-color: rgba(16,185,129,0.5);
+    background: var(--ps-online-dim);
+}
+.btn-outline-success:hover, .btn-outline-success:focus {
+    background: rgba(16,185,129,0.22);
+    border-color: var(--ps-online);
+    color: #6EE7B7;
+}
+
+.btn-outline-info {
+    color: var(--ps-cyan);
+    border-color: rgba(34,211,238,0.5);
+    background: var(--ps-cyan-dim);
+}
+.btn-outline-info:hover, .btn-outline-info:focus {
+    background: rgba(34,211,238,0.22);
+    border-color: var(--ps-cyan);
+    color: #A5F3FC;
 }
 
 .btn:focus, .btn:active:focus, .form-control:focus, .form-check-input:focus, .form-select:focus {
-    box-shadow: 0 0 0 3px rgba(14,165,233,0.2);
+    box-shadow: 0 0 0 3px var(--ps-cyan-dim);
     outline: none;
+    border-color: var(--ps-cyan);
 }
+
+.btn-link { color: var(--ps-cyan); }
 
 /* Cards */
 .card {
-    border: 1px solid var(--ps-border);
-    border-radius: 10px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.04), 0 1px 2px rgba(0,0,0,0.03);
-}
-
-.card-header {
-    background-color: #fff;
-    border-bottom: 1px solid var(--ps-border);
-    border-radius: 10px 10px 0 0 !important;
-    padding: 0.875rem 1.125rem;
-    font-weight: 600;
-    font-size: 0.875rem;
+    background: linear-gradient(180deg, rgba(20,33,58,0.85), rgba(15,26,46,0.85));
+    border: 1px solid var(--ps-line);
+    border-radius: var(--ps-radius);
+    box-shadow: 0 1px 0 rgba(255,255,255,0.03) inset, 0 1px 2px rgba(0,0,0,0.4);
     color: var(--ps-text);
 }
-
-.card-body {
-    padding: 1.125rem;
+.card-header {
+    background: rgba(8,14,26,0.5);
+    border-bottom: 1px solid var(--ps-line);
+    border-radius: var(--ps-radius) var(--ps-radius) 0 0 !important;
+    padding: 0.875rem 1.125rem;
+    font-weight: 600;
+    font-size: 12px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ps-text-2);
 }
+.card-body { padding: 1.125rem; }
 
-/* Badges */
+/* Badges — keep status colors vibrant */
 .badge {
-    font-weight: 500;
-    border-radius: 5px;
-    font-size: 0.75rem;
-    letter-spacing: 0.01em;
+    font-weight: 600;
+    border-radius: 999px;
+    font-size: 10.5px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 0.25em 0.6em;
+    border: 1px solid transparent;
+}
+.badge.bg-success {
+    background-color: var(--ps-online-dim) !important;
+    border-color: rgba(16,185,129,0.4);
+    color: var(--ps-online) !important;
+}
+.badge.bg-danger {
+    background-color: var(--ps-offline-dim) !important;
+    border-color: rgba(239,68,68,0.4);
+    color: var(--ps-offline) !important;
+}
+.badge.bg-warning {
+    background-color: var(--ps-warn-dim) !important;
+    border-color: rgba(245,158,11,0.4);
+    color: var(--ps-warn) !important;
+}
+.badge .bi-circle-fill {
+    font-size: 0.45rem;
+    filter: drop-shadow(0 0 4px currentColor);
 }
 
 /* Tables */
 .table {
-    font-size: 0.875rem;
+    font-size: 13px;
+    color: var(--ps-text);
+    --bs-table-bg: transparent;
+    --bs-table-color: var(--ps-text);
+    --bs-table-striped-bg: rgba(255,255,255,0.018);
+    --bs-table-striped-color: var(--ps-text);
+    --bs-table-hover-bg: rgba(34,211,238,0.05);
+    --bs-table-hover-color: var(--ps-text);
+    --bs-table-border-color: var(--ps-line);
+    border-color: var(--ps-line);
 }
-
-.table th {
-    font-size: 0.75rem;
-    font-weight: 600;
+.table thead th {
+    font-size: 10.5px;
+    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
-    color: var(--ps-text-muted);
-    border-bottom-width: 1px;
+    letter-spacing: 0.1em;
+    color: var(--ps-text-3);
+    border-bottom: 1px solid var(--ps-line-strong);
+    background: rgba(8,14,26,0.6);
+    padding: 0.6rem 0.85rem;
+    white-space: nowrap;
 }
-
 .table > :not(caption) > * > * {
-    padding: 0.75rem 1rem;
+    padding: 0.7rem 0.85rem;
+    border-bottom-color: var(--ps-line);
+    background-color: transparent;
+}
+.table-secondary > * {
+    --bs-table-bg-state: rgba(239,68,68,0.04);
+    color: var(--ps-text-2) !important;
+}
+.table-hover > tbody > tr:hover > * {
+    --bs-table-bg-state: rgba(34,211,238,0.05);
 }
 
 /* Alerts */
 .alert {
-    border-radius: 8px;
-    font-size: 0.875rem;
+    border-radius: var(--ps-radius);
+    font-size: 13px;
     border: 1px solid transparent;
+    backdrop-filter: blur(8px);
 }
-
 .alert-info {
-    background-color: #eff6ff;
-    border-color: #bfdbfe;
-    color: #1e40af;
+    background: rgba(34,211,238,0.08);
+    border-color: rgba(34,211,238,0.3);
+    color: #A5F3FC;
 }
-
 .alert-warning {
-    background-color: #fffbeb;
-    border-color: #fde68a;
-    color: #92400e;
+    background: var(--ps-warn-dim);
+    border-color: rgba(245,158,11,0.35);
+    color: #FCD34D;
 }
-
 .alert-danger {
-    background-color: #fef2f2;
-    border-color: #fecaca;
-    color: #991b1b;
+    background: var(--ps-offline-dim);
+    border-color: rgba(239,68,68,0.35);
+    color: #FCA5A5;
 }
-
 .alert-success {
-    background-color: #f0fdf4;
-    border-color: #bbf7d0;
-    color: #14532d;
+    background: var(--ps-online-dim);
+    border-color: rgba(16,185,129,0.35);
+    color: #6EE7B7;
+}
+.alert .btn-close {
+    filter: invert(1) brightness(1.5);
+    opacity: 0.7;
 }
 
 /* Forms */
 .form-control, .form-select {
-    border-radius: 6px;
-    border-color: var(--ps-border);
-    font-size: 0.875rem;
+    border-radius: var(--ps-radius-sm);
+    border: 1px solid var(--ps-line-strong);
+    background-color: var(--ps-bg-1);
+    font-size: 13px;
     color: var(--ps-text);
 }
-
+.form-control::placeholder { color: var(--ps-text-3); }
 .form-control:hover, .form-select:hover {
-    border-color: #cbd5e1;
+    border-color: var(--ps-line-strong);
+    background-color: var(--ps-bg-1);
 }
-
-.form-label {
-    font-size: 0.8125rem;
-    font-weight: 500;
+.form-control:focus, .form-select:focus {
+    background-color: var(--ps-bg-1);
     color: var(--ps-text);
-    margin-bottom: 0.375rem;
 }
+/* form-select chevron — Bootstrap's default chevron sits center-right and the
+   <select> text was rendering OVER it (looked like a V "watermark" behind the
+   value). Pin the chevron to the right edge with breathing room and ensure the
+   value never overlaps it. */
+.form-select {
+    background-color: var(--ps-bg-1);
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%2322D3EE' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 0.65rem center;
+    background-size: 12px 12px;
+    padding-right: 2.25rem;
+}
+.form-select-sm {
+    background-position: right 0.5rem center;
+    background-size: 10px 10px;
+    padding-right: 1.85rem;
+}
+/* The dropdown panel that opens when you click the select — browsers render
+   this with the OS theme by default, which on Windows/Chrome is white-on-white.
+   Force a dark panel so option labels are readable. */
+.form-select option,
+select option {
+    background-color: var(--ps-bg-2);
+    color: var(--ps-text);
+}
+.form-label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ps-text-2);
+    margin-bottom: 0.4rem;
+}
+.form-check-input {
+    background-color: var(--ps-bg-1);
+    border-color: var(--ps-line-strong);
+}
+.form-check-input:checked {
+    background-color: var(--ps-cyan);
+    border-color: var(--ps-cyan);
+}
+.form-text { color: var(--ps-text-3); font-size: 11.5px; }
 
 .input-group .form-control, .input-group .form-select {
-    border-radius: 6px 0 0 6px;
+    border-radius: var(--ps-radius-sm) 0 0 var(--ps-radius-sm);
 }
-
 .input-group .btn:last-child {
-    border-radius: 0 6px 6px 0;
+    border-radius: 0 var(--ps-radius-sm) var(--ps-radius-sm) 0;
 }
 
 /* List groups */
 .list-group-item {
-    font-size: 0.875rem;
-    border-color: var(--ps-border);
+    background: var(--ps-bg-2);
+    border-color: var(--ps-line);
+    color: var(--ps-text);
+    font-size: 13px;
 }
+.list-group-item-action:hover, .list-group-item-action:focus {
+    background: var(--ps-bg-3);
+    color: var(--ps-text);
+}
+
+/* ── Pages that don't apply our own components still need a dark surface.
+   Schedules / NDI / Versions etc lean on stock Bootstrap utility classes
+   (bg-white, bg-light, text-dark) which were producing white panels with
+   gray text — unreadable on the dark shell. Override Bootstrap globals. */
+.bg-white, .bg-light, .bg-body {
+    background-color: var(--ps-bg-2) !important;
+    color: var(--ps-text) !important;
+}
+.text-dark, .text-body {
+    color: var(--ps-text) !important;
+}
+.text-secondary {
+    color: var(--ps-text-2) !important;
+}
+.border, .border-top, .border-bottom, .border-start, .border-end {
+    border-color: var(--ps-line) !important;
+}
+/* Bootstrap helper that some pages use to get a panel look */
+.shadow-sm, .shadow {
+    box-shadow: 0 1px 3px rgba(0,0,0,0.4), 0 1px 2px rgba(0,0,0,0.3) !important;
+}
+
+/* Tabs/pills (used on a couple of admin pages) */
+.nav-tabs {
+    border-bottom-color: var(--ps-line);
+}
+.nav-tabs .nav-link {
+    color: var(--ps-text-2);
+    background: transparent;
+    border-color: transparent;
+}
+.nav-tabs .nav-link:hover {
+    color: var(--ps-text);
+    border-color: var(--ps-line) var(--ps-line) var(--ps-line);
+}
+.nav-tabs .nav-link.active {
+    color: var(--ps-cyan);
+    background: var(--ps-bg-2);
+    border-color: var(--ps-line) var(--ps-line) var(--ps-bg-2);
+}
+
+/* Dropdowns (Bootstrap dropdown menu, distinct from <select>) */
+.dropdown-menu {
+    background: var(--ps-bg-2);
+    border: 1px solid var(--ps-line-strong);
+    color: var(--ps-text);
+    box-shadow: 0 8px 24px rgba(0,0,0,0.5);
+}
+.dropdown-item {
+    color: var(--ps-text);
+}
+.dropdown-item:hover, .dropdown-item:focus {
+    background: var(--ps-bg-3);
+    color: var(--ps-text);
+}
+.dropdown-divider {
+    border-top-color: var(--ps-line);
+}
+
+/* Modal — dark theme */
+.modal-content {
+    background: linear-gradient(180deg, rgba(20,33,58,0.98), rgba(13,22,40,0.98));
+    border: 1px solid var(--ps-line-strong);
+    border-radius: var(--ps-radius-lg);
+    box-shadow: 0 20px 60px rgba(0,0,0,0.6), 0 0 0 1px var(--ps-line-glow);
+    color: var(--ps-text);
+    backdrop-filter: blur(20px);
+}
+.modal-header {
+    border-bottom: 1px solid var(--ps-line);
+    padding: 1rem 1.25rem;
+}
+.modal-title {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--ps-text);
+}
+.modal-footer { border-top: 1px solid var(--ps-line); }
+.btn-close {
+    filter: invert(1) brightness(1.5);
+    opacity: 0.7;
+}
+.btn-close:hover { opacity: 1; }
 
 /* Page subtitles */
 .text-muted {
-    color: var(--ps-text-muted) !important;
-    font-size: 0.875rem;
+    color: var(--ps-text-3) !important;
+    font-size: 13px;
 }
 
 /* ── Page header pattern ───────────────────────────────────────── */
 .page-header {
     margin-bottom: 1.5rem;
     padding-bottom: 1rem;
-    border-bottom: 1px solid var(--ps-border);
+    border-bottom: 1px solid var(--ps-line);
+    position: relative;
+}
+.page-header::after {
+    content: '';
+    position: absolute;
+    left: 0; bottom: -1px;
+    height: 1px; width: 80px;
+    background: linear-gradient(90deg, var(--ps-cyan), transparent);
 }
 
 /* ── Stat card ─────────────────────────────────────────────────── */
 .stat-card {
-    background: var(--ps-surface);
-    border: 1px solid var(--ps-border);
-    border-radius: 10px;
-    padding: 1.25rem;
+    background: linear-gradient(180deg, rgba(20,33,58,0.85), rgba(15,26,46,0.85));
+    border: 1px solid var(--ps-line);
+    border-radius: var(--ps-radius);
+    padding: 1.125rem 1.25rem;
     display: flex;
     align-items: flex-start;
     gap: 1rem;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+    box-shadow: 0 1px 0 rgba(255,255,255,0.03) inset;
+    transition: border-color 0.15s, transform 0.15s;
 }
+.stat-card:hover { border-color: var(--ps-line-strong); transform: translateY(-1px); }
 
 .stat-card-icon {
-    width: 2.75rem;
-    height: 2.75rem;
-    border-radius: 8px;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: var(--ps-radius-sm);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 1.1rem;
+    font-size: 1.05rem;
     flex-shrink: 0;
+    background: var(--ps-cyan-dim);
+    color: var(--ps-cyan);
+    border: 1px solid rgba(34,211,238,0.25);
 }
-
 .stat-card-value {
-    font-size: 1.625rem;
-    font-weight: 700;
+    font-family: var(--ps-mono);
+    font-size: 26px;
+    font-weight: 600;
     line-height: 1;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.01em;
     color: var(--ps-text);
 }
-
 .stat-card-label {
-    font-size: 0.75rem;
-    color: var(--ps-text-muted);
-    margin-top: 0.25rem;
-    font-weight: 500;
+    font-size: 10.5px;
+    color: var(--ps-text-3);
+    margin-top: 0.35rem;
+    font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.1em;
 }
 
 /* ── Validation ─────────────────────────────────────────────────── */
 .valid.modified:not([type=checkbox]) {
-    outline: 1px solid var(--ps-success);
+    outline: 1px solid var(--ps-online);
 }
-
 .invalid {
-    outline: 1px solid var(--ps-danger);
+    outline: 1px solid var(--ps-offline);
 }
-
 .validation-message {
-    color: var(--ps-danger);
-    font-size: 0.8125rem;
+    color: var(--ps-offline);
+    font-size: 12px;
 }
 
 /* ── Blazor error boundary ─────────────────────────────────────── */
 .blazor-error-boundary {
-    background: #fef2f2;
-    border: 1px solid #fecaca;
-    border-radius: 8px;
+    background: var(--ps-offline-dim);
+    border: 1px solid rgba(239,68,68,0.35);
+    border-radius: var(--ps-radius);
     padding: 1rem 1.25rem;
-    color: #991b1b;
-    font-size: 0.875rem;
+    color: #FCA5A5;
+    font-size: 13px;
 }
-
 .blazor-error-boundary::after {
     content: "An error has occurred."
+}
+
+/* ── Status pills (utility) ────────────────────────────────────── */
+.pill {
+    display: inline-flex; align-items: center; gap: 6px;
+    height: 22px; padding: 0 8px;
+    border-radius: 999px;
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    border: 1px solid transparent;
+}
+.pill .led {
+    width: 7px; height: 7px; border-radius: 50%;
+    background: currentColor;
+    box-shadow: 0 0 8px currentColor;
+}
+.pill--online   { color: var(--ps-online);  background: var(--ps-online-dim);  border-color: rgba(16,185,129,0.35); }
+.pill--warn     { color: var(--ps-warn);    background: var(--ps-warn-dim);    border-color: rgba(245,158,11,0.35); }
+.pill--offline  { color: var(--ps-offline); background: var(--ps-offline-dim); border-color: rgba(239,68,68,0.35); }
+.pill--info     { color: var(--ps-cyan);    background: var(--ps-cyan-dim);    border-color: rgba(34,211,238,0.35); }
+
+@keyframes pulse-led {
+    0%, 100% { transform: scale(1);   opacity: 1;   }
+    50%      { transform: scale(1.6); opacity: 0.4; }
+}
+.led-pulse { position: relative; }
+.led-pulse::after {
+    content: '';
+    position: absolute; inset: -3px;
+    border-radius: 50%;
+    background: currentColor;
+    opacity: 0.3;
+    animation: pulse-led 1.6s ease-out infinite;
 }


### PR DESCRIPTION
# PlainSight: Mission Control redesign

Reimagines the admin dashboard as an industrial NOC-style mission control. Dark surfaces, status-at-a-glance, telemetry-first device tiles. Wires real KPIs from `PlainSightDbContext` into the top bar.

## Files changed

| File | Change |
|---|---|
| `src/PlainSight.Server/wwwroot/app.css` | Replaced — new dark token system, restyled Bootstrap primitives (buttons, alerts, modals, tables, forms) |
| `src/PlainSight.Server/Components/Layout/MainLayout.razor` | Replaced — top bar now shows live system LED + active/degraded/offline KPIs (5s refresh) |
| `src/PlainSight.Server/Components/Layout/MainLayout.razor.css` | Replaced — glassmorphism top bar, scoped KPI styles |
| `src/PlainSight.Server/Components/Layout/NavMenu.razor` | Replaced — gradient logo mark, refined section labels, dedicated sign-out button |
| `src/PlainSight.Server/Components/Layout/NavMenu.razor.css` | Replaced — dark nav with cyan active-state rail |
| `src/PlainSight.Server/Components/Pages/Devices.razor` | Replaced — table swapped for status-filtered tile grid; same code-behind, same EF logic, plus `statusFilter` state and online/warn/offline split |
| `src/PlainSight.Server/Components/Pages/Devices.razor.css` | Replaced — tile, telemetry grid, bulk-action bar, status filter chips |

## Design system

- **Surfaces:** `#06090F → #0A111E → #0F1A2E → #14213A` (4-step dark scale)
- **Status:** Emerald `#10B981` · Amber `#F59E0B` · Crimson `#EF4444` (with halo glow + LED pulse)
- **Accents:** Cyan `#22D3EE` for primary, Blue `#3B82F6` for interactive
- **Type:** Inter (UI) + JetBrains Mono (telemetry/IDs)

All tokens declared in `:root` in `app.css` (`--ps-*` namespace).

## Behaviour parity

Everything from the original `Devices.razor` still works:
- 5-second auto-refresh timer (`refreshTimer`)
- Per-device screenshot request + history modal (`ShowScreenshotHistory`)
- Group reassignment (per-device dropdown + bulk move)
- API key reset
- Live mode editor (override / auto-switch / NDI source)
- Bulk screenshot, bulk move, bulk version assignment

New behaviour:
- **Status filter chips** (`All / Online / Degraded / Offline`) — three-tier status replaces the binary online/offline (`< 60s = online`, `< 5min = degraded`, else `offline`)
- **Top bar KPIs** — pulled from a fresh `LoadDevices`-style query in `MainLayout.razor` itself, refreshed every 5s alongside the existing per-page timer
- **Select all visible** — only selects devices matching the current status filter

## Compatibility notes

1. **Bootstrap** is still in use — the redesign restyles Bootstrap classes rather than removing them. No npm/bundler changes needed.
2. **CSS Isolation** — all new selectors in `MainLayout.razor.css`, `NavMenu.razor.css`, and `Devices.razor.css` are unprefixed and rely on Blazor's per-component scoping. The `::deep` selector on `.nav-link` is preserved (needed because `NavLink` renders an `<a>` not under direct CSS-isolation control).
3. **`/api/device/{deviceId}/screenshots/latest`** — the tile's thumbnail uses this endpoint. If your routing only exposes `/screenshots/{id}`, either add a `latest` shortcut or change the `<img src>` in `Devices.razor` to use `device.LatestScreenshotAt` to pick the most recent ID. Falls back gracefully to the "NO SCREENSHOT" empty state if not present.
4. **`Microsoft.AspNetCore.Components.Web` namespace** — `Devices.razor` uses `KeyboardEventArgs`. This was already imported via the existing `_Imports.razor`; no change needed.

## How to apply

```bash
git checkout -b mission-control-redesign
# Copy the seven files from pr/src/PlainSight.Server/... into the matching paths
git add src/PlainSight.Server
git commit -m "Redesign admin UI as Mission Control"
git push -u origin mission-control-redesign
gh pr create --title "Mission Control admin redesign" --body-file PR_DESCRIPTION.md
```

## Screenshots

See the prototype in `Mission Control.html` (React mock at the same fidelity as the final Blazor output).
