### PR TITLE
docs: add build status badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # PlainSight
 
+[![Server Build Status](https://github.com/glensouza/PlainSight/actions/workflows/server.yml/badge.svg)](https://github.com/glensouza/PlainSight/actions/workflows/server.yml)
+[![Player Build Status](https://github.com/glensouza/PlainSight/actions/workflows/player.yml/badge.svg)](https://github.com/glensouza/PlainSight/actions/workflows/player.yml)
+
 Enterprise-grade digital signage system for organizations, built with .NET 10 and optimized for Raspberry Pi 5.
 
 ## Name


### PR DESCRIPTION
## Description
This PR resolves #45 by adding GitHub Actions build status badges to the project's README.md file.

## Changes
- Added Server Build Status badge.
- Added Player Build Status badge.