### PR TITLE
feat: implement real server version display and device version monitoring

### DIFF
--- a/src/PlainSight.Server/Components/Layout/NavMenu.razor
+++ b/src/PlainSight.Server/Components/Layout/NavMenu.razor
@@ -1,3 +1,5 @@
+@inject PlainSight.Server.Services.VersionService VersionService
+
 <div class="sidebar-shell">
     <div class="sidebar-brand">
         <div class="sidebar-brand-mark">
@@ -16,7 +18,7 @@
         </div>
         <div>
             <div class="sidebar-brand-name">PlainSight</div>
-            <div class="sidebar-brand-sub">v2.4.1 · NOC</div>
+            <div class="sidebar-brand-sub">@VersionService.GetServerVersion() · NOC</div>
         </div>
     </div>
 

--- a/src/PlainSight.Server/Components/Pages/Devices.razor
+++ b/src/PlainSight.Server/Components/Pages/Devices.razor
@@ -4,6 +4,7 @@
 @inject IDbContextFactory<PlainSightDbContext> DbFactory
 @inject ILogger<Devices> Logger
 @inject IHttpClientFactory HttpClientFactory
+@inject PlainSight.Server.Services.VersionService VersionService
 @implements IDisposable
 
 <PageTitle>Devices — PlainSight</PageTitle>
@@ -126,7 +127,13 @@ else
                     </div>
                     <div class="ps-cell">
                         <div class="ps-cell__label">VERSION</div>
-                        <div class="ps-cell__value mono">@device.CurrentVersion</div>
+                        @{
+                            string targetVersion = GetTargetVersionForGroup(device.Group);
+                            bool isMismatch = device.CurrentVersion != targetVersion;
+                        }
+                        <div class="ps-cell__value mono @(isMismatch ? "is-mismatch" : "")" title="@(isMismatch ? $"Target: {targetVersion}" : "")">
+                            @device.CurrentVersion
+                        </div>
                     </div>
                     <div class="ps-cell">
                         <div class="ps-cell__label">GROUP</div>
@@ -461,6 +468,16 @@ else
     private string? bulkResultMessage;
     private bool bulkResultIsSuccess;
     private string statusFilter = "all";
+    private Dictionary<string, string> groupTargetVersions = [];
+
+    private string GetTargetVersionForGroup(string groupName)
+    {
+        if (groupTargetVersions.TryGetValue(groupName, out string? version))
+        {
+            return version;
+        }
+        return groupTargetVersions.GetValueOrDefault("Default", "1.0.0");
+    }
 
     private int OnlineCount => devices?.Count(d => GetStatusKey(d.LastSeen) == "online") ?? 0;
     private int WarnCount => devices?.Count(d => GetStatusKey(d.LastSeen) == "warn") ?? 0;
@@ -668,6 +685,10 @@ else
         {
             await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
             playerVersions = await context.PlayerVersions.OrderByDescending(v => v.VersionNumber).ToListAsync();
+
+            // Pre-load group targets for quick lookup
+            List<DeviceGroupVersion> targets = await context.DeviceGroupVersions.ToListAsync();
+            groupTargetVersions = targets.ToDictionary(t => t.GroupName, t => t.TargetVersion);
         }
         catch (Exception ex)
         {

--- a/src/PlainSight.Server/Components/Pages/Devices.razor.css
+++ b/src/PlainSight.Server/Components/Pages/Devices.razor.css
@@ -269,6 +269,11 @@
     text-overflow: ellipsis;
 }
 .ps-cell__value.mono { font-family: var(--ps-mono); color: var(--ps-text-mono); font-size: 11.5px; }
+.ps-cell__value.mono.is-mismatch {
+    color: var(--ps-warn);
+    font-weight: 600;
+    text-shadow: 0 0 8px var(--ps-warn-glow);
+}
 .ps-cell__select {
     width: 100%;
     background-color: transparent;

--- a/src/PlainSight.Server/Services/VersionService.cs
+++ b/src/PlainSight.Server/Services/VersionService.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using PlainSight.Server.Data;
 using PlainSight.Shared.Models;
@@ -6,6 +7,17 @@ namespace PlainSight.Server.Services;
 
 public class VersionService(PlainSightDbContext context, ILogger<VersionService> logger)
 {
+    public string GetServerVersion()
+    {
+        AssemblyInformationalVersionAttribute? attribute = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+
+        string version = attribute?.InformationalVersion ?? "1.0.0";
+
+        // If it's a long version string from git (e.g. 1.0.0+abc123), keep it as is or clean it up.
+        return $"v{version}";
+    }
+
     public async Task<string> GetTargetVersionAsync(string deviceGroup, CancellationToken cancellationToken = default)
     {
         List<DeviceGroupVersion> assignments = await context.DeviceGroupVersions


### PR DESCRIPTION
## Description
This PR resolves #43 by implementing real-time version tracking for both the server and the device fleet.

## Changes
- **Server Version:** Replaced the hardcoded 'v2.4.1' in the sidebar with the real AssemblyInformationalVersion.
- **Version Monitoring:** Added logic to Devices.razor to compare each device's CurrentVersion against its group's TargetVersion.
- **UI Feedback:** Devices with version mismatches now have their version string highlighted in amber (warning color) with a tooltip showing the target version.
- **Optimization:** Group target versions are pre-loaded in Devices.razor to minimize database hits during the 5-second auto-refresh cycle.

## Verification
- Project builds successfully.
- Sidebar displays real version (e.g., v1.0.0+sha).
- Version mismatch styling confirmed in CSS.