### PR TITLE
feat: implement unified logging for server and device fleet

### DIFF
--- a/src/PlainSight.Player/Program.cs
+++ b/src/PlainSight.Player/Program.cs
@@ -38,6 +38,11 @@ builder.Services.AddHttpClient<ScreenshotUploadService>(client =>
 }).RemoveAllResilienceHandlers();
 #pragma warning restore EXTEXP0001
 
+// Logging
+builder.Services.AddSingleton<LogBuffer>();
+builder.Services.AddSingleton<ILoggerProvider, PlayerLoggerProvider>();
+builder.Services.AddHostedService<LogRetentionService>();
+
 builder.Services.AddSingleton<ScreenCaptureService>();
 builder.Services.AddSingleton<NdiPlayerService>();
 

--- a/src/PlainSight.Player/Services/LogBuffer.cs
+++ b/src/PlainSight.Player/Services/LogBuffer.cs
@@ -1,0 +1,30 @@
+using System.Collections.Concurrent;
+using PlainSight.Shared.Models;
+
+namespace PlainSight.Player.Services;
+
+public class LogBuffer
+{
+    private readonly ConcurrentQueue<DeviceLogEntryDto> logs = new();
+
+    public void Enqueue(DeviceLogEntryDto entry)
+    {
+        this.logs.Enqueue(entry);
+        if (this.logs.Count > 1000)
+        {
+            this.logs.TryDequeue(out _);
+        }
+    }
+
+    public List<DeviceLogEntryDto> DequeueAll()
+    {
+        List<DeviceLogEntryDto> batch = [];
+        while (this.logs.TryDequeue(out DeviceLogEntryDto? entry))
+        {
+            batch.Add(entry);
+        }
+        return batch;
+    }
+
+    public bool IsEmpty => this.logs.IsEmpty;
+}

--- a/src/PlainSight.Player/Services/LogRetentionService.cs
+++ b/src/PlainSight.Player/Services/LogRetentionService.cs
@@ -1,0 +1,57 @@
+using System.Net.Http.Json;
+using PlainSight.Shared.Models;
+
+namespace PlainSight.Player.Services;
+
+public class LogRetentionService(
+    LogBuffer buffer,
+    IHttpClientFactory httpFactory,
+    IConfiguration configuration,
+    ILogger<LogRetentionService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(60), stoppingToken);
+
+                if (buffer.IsEmpty)
+                {
+                    continue;
+                }
+
+                string? deviceId = configuration["DeviceId"];
+                string? apiKey = configuration["ApiKey"];
+
+                if (string.IsNullOrEmpty(deviceId) || string.IsNullOrEmpty(apiKey))
+                {
+                    continue;
+                }
+
+                List<DeviceLogEntryDto> logs = buffer.DequeueAll();
+                DeviceLogBatchDto dto = new()
+                {
+                    DeviceId = deviceId,
+                    Logs = logs
+                };
+
+                using HttpClient http = httpFactory.CreateClient();
+                http.BaseAddress = new Uri(configuration["ServerUrl"] ?? "http://plainsight-server");
+                http.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+
+                HttpResponseMessage response = await http.PostAsJsonAsync("/api/device/logs", dto, stoppingToken);
+                if (!response.IsSuccessStatusCode)
+                {
+                    logger.LogWarning("Failed to upload logs to server: {StatusCode}", response.StatusCode);
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error uploading logs to server");
+            }
+        }
+    }
+}

--- a/src/PlainSight.Player/Services/PlayerLogger.cs
+++ b/src/PlainSight.Player/Services/PlayerLogger.cs
@@ -1,0 +1,32 @@
+using PlainSight.Shared.Models;
+
+namespace PlainSight.Player.Services;
+
+public class PlayerLogger(string category, LogBuffer buffer) : ILogger
+{
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Information;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        if (category.StartsWith("PlainSight.Player.Services.LogRetentionService"))
+        {
+            return;
+        }
+
+        buffer.Enqueue(new DeviceLogEntryDto
+        {
+            LogLevel = logLevel.ToString(),
+            Category = category,
+            Message = formatter(state, exception),
+            Exception = exception?.ToString(),
+            Timestamp = DateTime.UtcNow
+        });
+    }
+}

--- a/src/PlainSight.Player/Services/PlayerLoggerProvider.cs
+++ b/src/PlainSight.Player/Services/PlayerLoggerProvider.cs
@@ -1,0 +1,11 @@
+namespace PlainSight.Player.Services;
+
+public class PlayerLoggerProvider(LogBuffer buffer) : ILoggerProvider
+{
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new PlayerLogger(categoryName, buffer);
+    }
+
+    public void Dispose() { }
+}

--- a/src/PlainSight.Server/Api/DeviceApi.cs
+++ b/src/PlainSight.Server/Api/DeviceApi.cs
@@ -181,6 +181,47 @@ public static class DeviceApi
             }
         });
 
+        group.MapPost("/logs", async (DeviceLogBatchDto data, HttpContext httpContext, PlainSightDbContext context, LogQueue queue, ILoggerFactory loggerFactory, CancellationToken ct) =>
+        {
+            ILogger logger = loggerFactory.CreateLogger("DeviceApi");
+            try
+            {
+                Device? device = await context.Devices.FirstOrDefaultAsync(d => d.DeviceId == data.DeviceId, ct);
+                if (device == null || device.ApiKey == null)
+                {
+                    return Results.Unauthorized();
+                }
+
+                string? incomingKey = httpContext.Request.Headers["X-Api-Key"].FirstOrDefault();
+                if (string.IsNullOrEmpty(incomingKey) || !VerifyApiKey(incomingKey, device.ApiKey))
+                {
+                    logger.LogWarning("Logs rejected for device {DeviceId}: invalid or missing API key", SanitizeForLog(data.DeviceId));
+                    return Results.Unauthorized();
+                }
+
+                foreach (DeviceLogEntryDto log in data.Logs)
+                {
+                    queue.Enqueue(new LogEntry
+                    {
+                        Source = LogSource.Device,
+                        SourceId = data.DeviceId,
+                        LogLevel = log.LogLevel,
+                        Category = log.Category,
+                        Message = log.Message,
+                        Exception = log.Exception,
+                        Timestamp = log.Timestamp
+                    });
+                }
+
+                return Results.Ok();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error processing logs from device {DeviceId}", SanitizeForLog(data.DeviceId));
+                return Results.Problem("Internal server error", statusCode: 500);
+            }
+        });
+
         group.MapPost("/{deviceId}/screenshot/notify", async (
             string deviceId,
             HttpRequest request,

--- a/src/PlainSight.Server/Components/Layout/NavMenu.razor
+++ b/src/PlainSight.Server/Components/Layout/NavMenu.razor
@@ -74,6 +74,12 @@
         <div class="nav-section-label">System</div>
 
         <div class="nav-item">
+            <NavLink class="nav-link" href="logs">
+                <i class="bi bi-journal-text"></i> System Logs
+            </NavLink>
+        </div>
+
+        <div class="nav-item">
             <NavLink class="nav-link" href="versions">
                 <i class="bi bi-box-seam"></i> Software Versions
             </NavLink>

--- a/src/PlainSight.Server/Components/Pages/Logs.razor
+++ b/src/PlainSight.Server/Components/Pages/Logs.razor
@@ -1,0 +1,158 @@
+@page "/logs"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@using PlainSight.Server.Data
+@using PlainSight.Server.Services
+@using PlainSight.Shared.Models
+@using Microsoft.EntityFrameworkCore
+@inject IDbContextFactory<PlainSightDbContext> DbFactory
+@inject ILogger<Logs> Logger
+
+<PageTitle>System Logs — PlainSight</PageTitle>
+
+<div class="page-header">
+    <h1>System Logs</h1>
+    <p class="text-muted mb-0">Centralized logs from the server and device fleet</p>
+</div>
+
+<div class="ps-toolbar">
+    <div class="ps-toolbar__filters">
+        <select class="ps-cell__select filter-select" @bind="sourceFilter">
+            <option value="">All Sources</option>
+            <option value="Server">Server</option>
+            <option value="Device">Devices</option>
+        </select>
+        
+        <select class="ps-cell__select filter-select" @bind="levelFilter">
+            <option value="">All Levels</option>
+            <option value="Information">Information</option>
+            <option value="Warning">Warning</option>
+            <option value="Error">Error</option>
+            <option value="Critical">Critical</option>
+        </select>
+
+        <button class="btn btn-sm btn-primary" @onclick="LoadLogs">
+            <i class="bi bi-filter"></i> Apply
+        </button>
+    </div>
+    <div class="ps-toolbar__actions">
+        <button class="btn btn-sm btn-outline-secondary" @onclick="LoadLogs">
+            <i class="bi bi-arrow-clockwise"></i> Refresh
+        </button>
+    </div>
+</div>
+
+@if (logs == null)
+{
+    <p><em>Loading logs...</em></p>
+}
+else if (!logs.Any())
+{
+    <div class="alert alert-info">
+        <i class="bi bi-info-circle"></i> No logs found matching the criteria.
+    </div>
+}
+else
+{
+    <div class="ps-table-container">
+        <table class="ps-table">
+            <thead>
+                <tr>
+                    <th>TIMESTAMP</th>
+                    <th>SOURCE</th>
+                    <th>LEVEL</th>
+                    <th>CATEGORY</th>
+                    <th>MESSAGE</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (LogEntry log in logs)
+                {
+                    <tr class="log-row--@log.LogLevel.ToLower()">
+                        <td class="text-nowrap mono">@log.Timestamp.ToLocalTime().ToString("MM-dd HH:mm:ss")</td>
+                        <td class="text-nowrap">
+                            <span class="badge @(log.Source == LogSource.Server ? "bg-primary" : "bg-info")">
+                                @log.Source: @log.SourceId
+                            </span>
+                        </td>
+                        <td class="text-nowrap">
+                            <span class="pill pill--@GetLevelClass(log.LogLevel)">
+                                <span class="led"></span>
+                                @log.LogLevel
+                            </span>
+                        </td>
+                        <td class="text-muted small">
+                            <div class="category-text" title="@log.Category">@TruncateCategory(log.Category)</div>
+                        </td>
+                        <td>
+                            <div class="log-message">@log.Message</div>
+                            @if (!string.IsNullOrEmpty(log.Exception))
+                            {
+                                <pre class="log-exception mt-1">@log.Exception</pre>
+                            }
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+
+@code {
+    private List<LogEntry>? logs;
+    private string sourceFilter = string.Empty;
+    private string levelFilter = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadLogs();
+    }
+
+    private async Task LoadLogs()
+    {
+        try
+        {
+            await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
+            IQueryable<LogEntry> query = context.LogEntries.AsNoTracking();
+
+            if (!string.IsNullOrEmpty(sourceFilter))
+            {
+                LogSource source = Enum.Parse<LogSource>(sourceFilter);
+                query = query.Where(l => l.Source == source);
+            }
+
+            if (!string.IsNullOrEmpty(levelFilter))
+            {
+                query = query.Where(l => l.LogLevel == levelFilter);
+            }
+
+            logs = await query
+                .OrderByDescending(l => l.Timestamp)
+                .Take(200)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading logs");
+            logs = [];
+        }
+    }
+
+    private static string GetLevelClass(string level) => level switch
+    {
+        "Information" => "online",
+        "Warning" => "warn",
+        "Error" or "Critical" => "offline",
+        _ => "muted"
+    };
+
+    private static string TruncateCategory(string category)
+    {
+        if (string.IsNullOrEmpty(category))
+        {
+            return string.Empty;
+        }
+        string[] parts = category.Split('.');
+        return parts.Last();
+    }
+}

--- a/src/PlainSight.Server/Components/Pages/Logs.razor.css
+++ b/src/PlainSight.Server/Components/Pages/Logs.razor.css
@@ -1,0 +1,98 @@
+.ps-table-container {
+    background: var(--ps-glass);
+    border: 1px solid var(--ps-line);
+    border-radius: var(--ps-radius);
+    overflow: hidden;
+    margin-bottom: 2rem;
+}
+
+.ps-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+}
+
+.ps-table th {
+    background: var(--ps-bg-3);
+    padding: 10px 14px;
+    text-align: left;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    color: var(--ps-text-3);
+    border-bottom: 1px solid var(--ps-line-strong);
+}
+
+.ps-table td {
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--ps-line);
+    vertical-align: top;
+}
+
+.ps-table tr:hover {
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.mono {
+    font-family: var(--ps-mono);
+    font-size: 11px;
+    color: var(--ps-text-mono);
+}
+
+.pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    background: var(--ps-bg-3);
+    border: 1px solid var(--ps-line);
+}
+
+.pill--online { color: var(--ps-online); border-color: rgba(16,185,129,0.3); }
+.pill--online .led { background: var(--ps-online); box-shadow: 0 0 6px var(--ps-online-glow); }
+
+.pill--warn { color: var(--ps-warn); border-color: rgba(245,158,11,0.3); }
+.pill--warn .led { background: var(--ps-warn); box-shadow: 0 0 6px var(--ps-warn-glow); }
+
+.pill--offline { color: var(--ps-offline); border-color: rgba(239,68,68,0.3); }
+.pill--offline .led { background: var(--ps-offline); box-shadow: 0 0 6px var(--ps-offline-glow); }
+
+.led { width: 6px; height: 6px; border-radius: 50%; display: inline-block; }
+
+.log-message {
+    white-space: pre-wrap;
+    word-break: break-word;
+    line-height: 1.4;
+}
+
+.log-exception {
+    font-family: var(--ps-mono);
+    font-size: 11px;
+    background: rgba(0, 0, 0, 0.3);
+    padding: 8px;
+    border-radius: 4px;
+    color: var(--ps-offline);
+    overflow-x: auto;
+    max-height: 200px;
+}
+
+.filter-select {
+    width: 140px;
+    background: var(--ps-bg-1);
+    border: 1px solid var(--ps-line-strong);
+    border-radius: 4px;
+    color: var(--ps-text);
+    padding: 4px 8px;
+}
+
+.category-text {
+    max-width: 150px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/src/PlainSight.Server/Data/PlainSightDbContext.cs
+++ b/src/PlainSight.Server/Data/PlainSightDbContext.cs
@@ -18,10 +18,18 @@ public class PlainSightDbContext(DbContextOptions<PlainSightDbContext> options) 
     public DbSet<ScheduleTargetGroup> ScheduleTargetGroups => this.Set<ScheduleTargetGroup>();
     public DbSet<NdiSource> NdiSources => this.Set<NdiSource>();
     public DbSet<SystemSetting> SystemSettings => this.Set<SystemSetting>();
+    public DbSet<LogEntry> LogEntries => this.Set<LogEntry>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<LogEntry>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasIndex(e => new { e.Source, e.SourceId, e.Timestamp });
+            entity.Property(e => e.Source).HasConversion<string>();
+        });
 
         modelBuilder.Entity<SystemSetting>(entity =>
         {

--- a/src/PlainSight.Server/Migrations/20260505070005_AddUnifiedLogging.Designer.cs
+++ b/src/PlainSight.Server/Migrations/20260505070005_AddUnifiedLogging.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PlainSight.Server.Data;
@@ -11,9 +12,11 @@ using PlainSight.Server.Data;
 namespace PlainSight.Server.Migrations
 {
     [DbContext(typeof(PlainSightDbContext))]
-    partial class PlainSightDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260505070005_AddUnifiedLogging")]
+    partial class AddUnifiedLogging
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PlainSight.Server/Migrations/20260505070005_AddUnifiedLogging.cs
+++ b/src/PlainSight.Server/Migrations/20260505070005_AddUnifiedLogging.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace PlainSight.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUnifiedLogging : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LogEntries",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Source = table.Column<string>(type: "text", nullable: false),
+                    SourceId = table.Column<string>(type: "text", nullable: true),
+                    LogLevel = table.Column<string>(type: "text", nullable: false),
+                    Category = table.Column<string>(type: "text", nullable: false),
+                    Message = table.Column<string>(type: "text", nullable: false),
+                    Exception = table.Column<string>(type: "text", nullable: true),
+                    Timestamp = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LogEntries", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LogEntries_Source_SourceId_Timestamp",
+                table: "LogEntries",
+                columns: new[] { "Source", "SourceId", "Timestamp" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LogEntries");
+        }
+    }
+}

--- a/src/PlainSight.Server/Program.cs
+++ b/src/PlainSight.Server/Program.cs
@@ -34,6 +34,11 @@ builder.Services.AddRazorComponents()
 
 builder.Services.AddOpenApi();
 
+// Logging
+builder.Services.AddSingleton<LogQueue>();
+builder.Services.AddSingleton<ILoggerProvider, DbLoggerProvider>();
+builder.Services.AddHostedService<LogFlushService>();
+
 // Add database context factory
 builder.Services.AddDbContextFactory<PlainSightDbContext>(options =>
 {

--- a/src/PlainSight.Server/Services/DbLogger.cs
+++ b/src/PlainSight.Server/Services/DbLogger.cs
@@ -1,0 +1,39 @@
+using PlainSight.Shared.Models;
+
+namespace PlainSight.Server.Services;
+
+public class DbLogger(string category, LogQueue queue) : ILogger
+{
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Information;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        // Avoid recursion and noise
+        if (category.StartsWith("Microsoft.EntityFrameworkCore") || 
+            category.StartsWith("Microsoft.AspNetCore.Hosting.Diagnostics") ||
+            category.StartsWith("PlainSight.Server.Services.LogFlushService"))
+        {
+            return;
+        }
+
+        string message = formatter(state, exception);
+        
+        queue.Enqueue(new LogEntry
+        {
+            Source = LogSource.Server,
+            SourceId = "Server",
+            LogLevel = logLevel.ToString(),
+            Category = category,
+            Message = message,
+            Exception = exception?.ToString(),
+            Timestamp = DateTime.UtcNow
+        });
+    }
+}

--- a/src/PlainSight.Server/Services/DbLoggerProvider.cs
+++ b/src/PlainSight.Server/Services/DbLoggerProvider.cs
@@ -1,0 +1,11 @@
+namespace PlainSight.Server.Services;
+
+public class DbLoggerProvider(LogQueue queue) : ILoggerProvider
+{
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new DbLogger(categoryName, queue);
+    }
+
+    public void Dispose() { }
+}

--- a/src/PlainSight.Server/Services/LogFlushService.cs
+++ b/src/PlainSight.Server/Services/LogFlushService.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+using PlainSight.Server.Data;
+using PlainSight.Shared.Models;
+
+namespace PlainSight.Server.Services;
+
+public class LogFlushService(
+    LogQueue queue, 
+    IDbContextFactory<PlainSightDbContext> dbContextFactory,
+    ILogger<LogFlushService> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+
+                List<LogEntry> batch = queue.DequeueAll();
+                if (batch.Count == 0)
+                {
+                    continue;
+                }
+
+                await using PlainSightDbContext context = await dbContextFactory.CreateDbContextAsync(stoppingToken);
+                context.LogEntries.AddRange(batch);
+                await context.SaveChangesAsync(stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected on shutdown
+            }
+            catch (Exception ex)
+            {
+                // Log to stderr at least
+                Console.Error.WriteLine($"Error flushing logs to database: {ex}");
+            }
+        }
+    }
+}

--- a/src/PlainSight.Server/Services/LogQueue.cs
+++ b/src/PlainSight.Server/Services/LogQueue.cs
@@ -1,0 +1,30 @@
+using System.Collections.Concurrent;
+using PlainSight.Shared.Models;
+
+namespace PlainSight.Server.Services;
+
+public class LogQueue
+{
+    private readonly ConcurrentQueue<LogEntry> logs = new();
+
+    public void Enqueue(LogEntry entry)
+    {
+        this.logs.Enqueue(entry);
+        
+        // Limit queue size to prevent memory leaks if DB is down
+        if (this.logs.Count > 1000)
+        {
+            this.logs.TryDequeue(out _);
+        }
+    }
+
+    public List<LogEntry> DequeueAll()
+    {
+        List<LogEntry> batch = [];
+        while (this.logs.TryDequeue(out LogEntry? entry))
+        {
+            batch.Add(entry);
+        }
+        return batch;
+    }
+}

--- a/src/PlainSight.Shared/Models/DeviceLogBatchDto.cs
+++ b/src/PlainSight.Shared/Models/DeviceLogBatchDto.cs
@@ -1,0 +1,7 @@
+namespace PlainSight.Shared.Models;
+
+public class DeviceLogBatchDto
+{
+    public string DeviceId { get; set; } = string.Empty;
+    public List<DeviceLogEntryDto> Logs { get; set; } = [];
+}

--- a/src/PlainSight.Shared/Models/DeviceLogEntryDto.cs
+++ b/src/PlainSight.Shared/Models/DeviceLogEntryDto.cs
@@ -1,0 +1,10 @@
+namespace PlainSight.Shared.Models;
+
+public class DeviceLogEntryDto
+{
+    public string LogLevel { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public string? Exception { get; set; }
+    public DateTime Timestamp { get; set; }
+}

--- a/src/PlainSight.Shared/Models/LogEntry.cs
+++ b/src/PlainSight.Shared/Models/LogEntry.cs
@@ -1,0 +1,19 @@
+namespace PlainSight.Shared.Models;
+
+public enum LogSource
+{
+    Server,
+    Device
+}
+
+public class LogEntry
+{
+    public int Id { get; init; }
+    public LogSource Source { get; set; }
+    public string? SourceId { get; set; } // DeviceId or "Server"
+    public string LogLevel { get; set; } = string.Empty;
+    public string Category { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public string? Exception { get; set; }
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+}


### PR DESCRIPTION
## Description
This PR resolves #46 by implementing a unified, centralized logging system that aggregates logs from both the control plane (Server) and the edge fleet (Players).

## Changes
- **Database Schema:** Added a LogEntries table to store logs from all sources with indexing for fast filtering.
- **Server Logging:** Implemented a DbLoggerProvider that captures server-side ILogger output and flushes it to the database via a background service (LogFlushService) to avoid blocking performance.
- **Device API:** Added a batching API endpoint (/api/device/logs) that allows players to securely upload logs using their API keys.
- **Player Logging:** Added a LogRetentionService to the Raspberry Pi player that buffers logs locally and ships them to the server every 60 seconds.
- **Admin Dashboard:** Created a new **System Logs** page with real-time data, filtering by Source (Server/Device), Log Level, and automatic category truncation for readability.

## Verification
- Both Server and Player projects build successfully.
- Migration generated and verified.
- Navigation link added to the sidebar.