### PR TITLE
feat: real-time version tracking and server version display (issue #43)

### DIFF
--- a/src/PlainSight.Server/Components/Layout/NavMenu.razor
+++ b/src/PlainSight.Server/Components/Layout/NavMenu.razor
@@ -1,3 +1,5 @@
+@inject PlainSight.Server.Services.VersionService VersionService
+
 <div class="sidebar-shell">
     <div class="sidebar-brand">
         <div class="sidebar-brand-mark">
@@ -5,7 +7,7 @@
         </div>
         <div>
             <div class="sidebar-brand-name">PlainSight</div>
-            <div class="sidebar-brand-sub">v2.4.1 · NOC</div>
+            <div class="sidebar-brand-sub">@VersionService.GetServerVersion() · NOC</div>
         </div>
     </div>
 

--- a/src/PlainSight.Server/Components/Pages/Devices.razor
+++ b/src/PlainSight.Server/Components/Pages/Devices.razor
@@ -5,6 +5,7 @@
 @inject ILogger<Devices> Logger
 @inject IHttpClientFactory HttpClientFactory
 @inject ScreenshotNotificationService ScreenshotNotificationService
+@inject PlainSight.Server.Services.VersionService VersionService
 @implements IAsyncDisposable
 
 <PageTitle>Devices — PlainSight</PageTitle>
@@ -123,7 +124,13 @@ else
                     </div>
                     <div class="ps-cell">
                         <div class="ps-cell__label">VERSION</div>
-                        <div class="ps-cell__value mono">@device.CurrentVersion</div>
+                        @{
+                            string targetVersion = GetTargetVersionForGroup(device.Group);
+                            bool isMismatch = device.CurrentVersion != targetVersion;
+                        }
+                        <div class="ps-cell__value mono @(isMismatch ? "is-mismatch" : "")" title="@(isMismatch ? $"Target: {targetVersion}" : "")">
+                            @device.CurrentVersion
+                        </div>
                     </div>
                     <div class="ps-cell">
                         <div class="ps-cell__label">GROUP</div>
@@ -464,6 +471,16 @@ else
     private string? bulkResultMessage;
     private bool bulkResultIsSuccess;
     private string statusFilter = "all";
+    private Dictionary<string, string> groupTargetVersions = [];
+
+    private string GetTargetVersionForGroup(string groupName)
+    {
+        if (groupTargetVersions.TryGetValue(groupName, out string? version))
+        {
+            return version;
+        }
+        return groupTargetVersions.GetValueOrDefault("Default", "1.0.0");
+    }
 
     private int OnlineCount => devices?.Count(d => GetStatusKey(d.LastSeen) == "online") ?? 0;
     private int WarnCount => devices?.Count(d => GetStatusKey(d.LastSeen) == "warn") ?? 0;
@@ -719,6 +736,10 @@ else
         {
             await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
             playerVersions = await context.PlayerVersions.OrderByDescending(v => v.VersionNumber).ToListAsync();
+
+            // Pre-load group targets for quick lookup
+            List<DeviceGroupVersion> targets = await context.DeviceGroupVersions.ToListAsync();
+            groupTargetVersions = targets.ToDictionary(t => t.GroupName, t => t.TargetVersion);
         }
         catch (Exception ex)
         {

--- a/src/PlainSight.Server/Components/Pages/Devices.razor
+++ b/src/PlainSight.Server/Components/Pages/Devices.razor
@@ -5,7 +5,6 @@
 @inject ILogger<Devices> Logger
 @inject IHttpClientFactory HttpClientFactory
 @inject ScreenshotNotificationService ScreenshotNotificationService
-@inject PlainSight.Server.Services.VersionService VersionService
 @implements IAsyncDisposable
 
 <PageTitle>Devices — PlainSight</PageTitle>
@@ -128,7 +127,13 @@ else
                             string targetVersion = GetTargetVersionForGroup(device.Group);
                             bool isMismatch = device.CurrentVersion != targetVersion;
                         }
-                        <div class="ps-cell__value mono @(isMismatch ? "is-mismatch" : "")" title="@(isMismatch ? $"Target: {targetVersion}" : "")">
+                        <div class="ps-cell__value mono @(isMismatch ? "is-mismatch" : "")"
+                             title="@(isMismatch ? $"Target: {targetVersion}" : "")"
+                             aria-label="@(isMismatch ? $"Version {device.CurrentVersion}, target: {targetVersion}" : device.CurrentVersion)">
+                            @if (isMismatch)
+                            {
+                                <i class="bi bi-exclamation-triangle-fill me-1" aria-hidden="true"></i>
+                            }
                             @device.CurrentVersion
                         </div>
                     </div>
@@ -623,6 +628,8 @@ else
                 .Include(d => d.AssignedNdiSource)
                 .OrderByDescending(d => d.LastSeen)
                 .ToListAsync();
+            List<DeviceGroupVersion> targets = await context.DeviceGroupVersions.ToListAsync();
+            groupTargetVersions = targets.ToDictionary(t => t.GroupName, t => t.TargetVersion);
         }
         catch (Exception ex)
         {
@@ -736,10 +743,6 @@ else
         {
             await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
             playerVersions = await context.PlayerVersions.OrderByDescending(v => v.VersionNumber).ToListAsync();
-
-            // Pre-load group targets for quick lookup
-            List<DeviceGroupVersion> targets = await context.DeviceGroupVersions.ToListAsync();
-            groupTargetVersions = targets.ToDictionary(t => t.GroupName, t => t.TargetVersion);
         }
         catch (Exception ex)
         {

--- a/src/PlainSight.Server/Components/Pages/Devices.razor.css
+++ b/src/PlainSight.Server/Components/Pages/Devices.razor.css
@@ -271,6 +271,11 @@
     text-overflow: ellipsis;
 }
 .ps-cell__value.mono { font-family: var(--ps-mono); color: var(--ps-text-mono); font-size: 11.5px; }
+.ps-cell__value.mono.is-mismatch {
+    color: var(--ps-warn);
+    font-weight: 600;
+    text-shadow: 0 0 8px var(--ps-warn-glow);
+}
 .ps-cell__select {
     width: 100%;
     background-color: transparent;

--- a/src/PlainSight.Server/Program.cs
+++ b/src/PlainSight.Server/Program.cs
@@ -69,7 +69,7 @@ builder.Services.AddSingleton<RenderQueue>();
 builder.Services.AddHostedService<RenderWorkerService>();
 builder.Services.AddScoped<ContentSyncService>();
 builder.Services.AddHostedService<ContentSyncWorkerService>();
-builder.Services.AddScoped<VersionService>();
+builder.Services.AddSingleton<VersionService>();
 builder.Services.AddSingleton<SignatureVerifier>(sp =>
 {
     IConfiguration config = sp.GetRequiredService<IConfiguration>();

--- a/src/PlainSight.Server/Services/VersionService.cs
+++ b/src/PlainSight.Server/Services/VersionService.cs
@@ -5,7 +5,7 @@ using PlainSight.Shared.Models;
 
 namespace PlainSight.Server.Services;
 
-public class VersionService(PlainSightDbContext context, ILogger<VersionService> logger)
+public class VersionService(IDbContextFactory<PlainSightDbContext> dbFactory, ILogger<VersionService> logger)
 {
     public string GetServerVersion()
     {
@@ -14,12 +14,12 @@ public class VersionService(PlainSightDbContext context, ILogger<VersionService>
 
         string version = attribute?.InformationalVersion ?? "1.0.0";
 
-        // If it's a long version string from git (e.g. 1.0.0+abc123), keep it as is or clean it up.
         return $"v{version}";
     }
 
     public async Task<string> GetTargetVersionAsync(string deviceGroup, CancellationToken cancellationToken = default)
     {
+        await using PlainSightDbContext context = await dbFactory.CreateDbContextAsync(cancellationToken);
         List<DeviceGroupVersion> assignments = await context.DeviceGroupVersions
             .Where(g => g.GroupName == deviceGroup || g.GroupName == "Default")
             .ToListAsync(cancellationToken);

--- a/src/PlainSight.Server/Services/VersionService.cs
+++ b/src/PlainSight.Server/Services/VersionService.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using PlainSight.Server.Data;
 using PlainSight.Shared.Models;
@@ -6,6 +7,17 @@ namespace PlainSight.Server.Services;
 
 public class VersionService(PlainSightDbContext context, ILogger<VersionService> logger)
 {
+    public string GetServerVersion()
+    {
+        AssemblyInformationalVersionAttribute? attribute = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+
+        string version = attribute?.InformationalVersion ?? "1.0.0";
+
+        // If it's a long version string from git (e.g. 1.0.0+abc123), keep it as is or clean it up.
+        return $"v{version}";
+    }
+
     public async Task<string> GetTargetVersionAsync(string deviceGroup, CancellationToken cancellationToken = default)
     {
         List<DeviceGroupVersion> assignments = await context.DeviceGroupVersions


### PR DESCRIPTION
This PR replaces #50. It implements real-time version tracking for both the server and the device fleet. Rebased onto main to resolve conflicts with recent UI changes. Closes #43