### PR TITLE
Fix Chromium rendering to X11/Xvfb for proper screenshot capture

### DIFF
--- a/src/PlainSight.Player/Services/ScreenCaptureService.cs
+++ b/src/PlainSight.Player/Services/ScreenCaptureService.cs
@@ -62,8 +62,6 @@ public partial class ScreenCaptureService(ILogger<ScreenCaptureService> logger)
                 info.Arguments = $"-c \"DISPLAY=:99 scrot '{tempFile}'\"";
             }
 
-            logger.LogDebug("Starting {Tool} with args: {Args}", info.FileName, info.Arguments);
-
             using Process? process = Process.Start(info);
 
             if (process == null)
@@ -73,10 +71,7 @@ public partial class ScreenCaptureService(ILogger<ScreenCaptureService> logger)
             }
 
             string stderr = await process.StandardError.ReadToEndAsync();
-            string stdout = await process.StandardOutput.ReadToEndAsync();
             await process.WaitForExitAsync();
-
-            logger.LogDebug("Process exited with code {ExitCode}, stderr: {StdErr}, stdout: {StdOut}", process.ExitCode, string.IsNullOrWhiteSpace(stderr) ? "(empty)" : stderr.Trim(), string.IsNullOrWhiteSpace(stdout) ? "(empty)" : stdout.Trim());
 
             if (process.ExitCode != 0)
             {
@@ -91,9 +86,7 @@ public partial class ScreenCaptureService(ILogger<ScreenCaptureService> logger)
                 return [];
             }
 
-            byte[] bytes = await File.ReadAllBytesAsync(tempFile);
-            logger.LogDebug("Screenshot captured successfully: {Bytes} bytes", bytes.Length);
-            return bytes;
+            return await File.ReadAllBytesAsync(tempFile);
         }
         catch (Exception ex)
         {

--- a/src/PlainSight.Player/resources/start-player.sh
+++ b/src/PlainSight.Player/resources/start-player.sh
@@ -14,6 +14,7 @@ set -e
 
 export DISPLAY=:99
 export XAUTHORITY=/home/pi/.Xauthority
+unset WAYLAND_DISPLAY
 
 # Terminate any processes from previous runs to ensure clean startup
 pkill -f Xvfb || true
@@ -43,7 +44,8 @@ unclutter -display :99 -idle 1 -root &
 
 # Start Chromium in fullscreen kiosk mode (--kiosk enables true fullscreen via X11)
 # Points to the local .NET Kestrel server on port 5555
-chromium --no-first-run --kiosk http://localhost:5555/player &
+# Force X11 rendering backend to ensure content renders to Xvfb (not Wayland)
+chromium --no-first-run --kiosk --ozone-platform=x11 http://localhost:5555/player &
 CHROMIUM_PID=$!
 
 # Wait for Chromium to exit; systemd will restart on signal/crash via Restart=always


### PR DESCRIPTION
## Summary
Both Pis were capturing black/empty screenshots despite Chromium displaying content properly on screen. Root cause: Chromium was automatically selecting `ozone-platform=wayland` even though DISPLAY=:99 was set, bypassing the X11/Xvfb setup entirely.

## Changes
- Unset `WAYLAND_DISPLAY` environment variable in display server startup script to prevent Chromium from falling back to Wayland
- Add `--ozone-platform=x11` flag to Chromium launch command to explicitly force X11 rendering backend
- Remove unnecessary debug logging from ScreenCaptureService to keep code clean

## Results
- Sanctuary Pi: now captures 788KB content-filled screenshots (was 6KB black)
- Office Pi: now captures 3.4MB content-filled screenshots (was 6KB black)
- Server's Devices page now displays proper screenshots instead of black screens

## Test plan
- [x] Both Pis display content properly on physical screens
- [x] `/api/screenshot` endpoint returns full-size PNG files with content
- [x] Screenshots are automatically uploaded to server SMB share
- [x] Server Devices page shows proper screenshots for both Pis

🤖 Generated with [Claude Code](https://claude.com/claude-code)