### PR TITLE
Replace companion clip pairing with an Announcement entity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ docker compose up -d
 ### Key files to read first
 
 - `src/PlainSight.AppHost/AppHost.cs` — Aspire wiring; PostgreSQL uses `ContainerLifetime.Persistent`
-- `src/PlainSight.Server/Data/PlainSightDbContext.cs` — EF Core context with 16 entity types: `Device`, `ContentItem`, `Playlist`, `PlaylistItem`, `Schedule`, `ScheduleTargetGroup`, `BrandingVideo`, `BrandingSchedule`, `NdiSource`, `LogEntry`, `PlayerVersion`, `DeviceGroup`, `DeviceGroupVersion`, `DeviceScreenshot`, `SystemSetting`, `AdminUser`
+- `src/PlainSight.Server/Data/PlainSightDbContext.cs` — EF Core context with 18 entity types: `Device`, `ContentItem`, `Playlist`, `PlaylistItem`, `Announcement`, `AnnouncementMedia`, `Schedule`, `ScheduleTargetGroup`, `BrandingVideo`, `BrandingSchedule`, `NdiSource`, `LogEntry`, `PlayerVersion`, `DeviceGroup`, `DeviceGroupVersion`, `DeviceScreenshot`, `SystemSetting`, `AdminUser`
 - `src/PlainSight.Server/Program.cs` — Service registration; DB migrations run at startup via `Migrate()`
 - `src/PlainSight.Server/Api/DeviceApi.cs` — Heartbeat endpoint is the system's spine; X-Api-Key TOFU auth, playlist delivery, live-mode decisions, screenshot burst triggers
 - `src/PlainSight.Server/Services/ContentSyncService.cs` — Holds `SyncLock` (static `SemaphoreSlim`) across file write + DB insert to prevent unique `FileName` constraint violations (see commit a332c72)
@@ -98,13 +98,15 @@ Device endpoints (`/heartbeat`, `/logs`, `/screenshot/notify`) use `X-Api-Key` h
 
 ### Blazor pages
 
-All pages in `src/PlainSight.Server/Components/Pages/` use `@rendermode InteractiveServer`. The `Devices` page auto-refreshes every 5 seconds via a `Timer`. The `Versions` page currently uses in-memory hardcoded data — version management is not yet database-driven.
+All pages in `src/PlainSight.Server/Components/Pages/` use `@rendermode InteractiveServer`. The `Devices` page auto-refreshes every 5 seconds via a `Timer`. The `Versions` page currently uses in-memory hardcoded data — version management is not yet database-driven. The `Announcements` page manages `Announcement`/`AnnouncementMedia` records (title, event date, expiration, ordered media); `Playlists` can add an `Announcement` as a playlist item alongside plain `ContentItem`s.
 
 ### Database schema
 
-`PlainSightDbContext` manages 16 entity types. `Device.DeviceId` (string, unique) is the natural key used in all player/API interactions. `ContentItem.FileName` is unique. `Playlist` → `PlaylistItem` → `ContentItem` with cascade delete on `PlaylistItem` and restrict on `ContentItem`. `Schedule` has a `Playlist` FK (cascade) and many `ScheduleTargetGroup` entries. `NdiSource.ServiceName` is unique, and `Device` has a nullable FK to `NdiSource`. `BrandingSchedule` references `BrandingVideo` (cascade). `LogEntry` is bulk-inserted from a bounded channel. `PlayerVersion` and `DeviceGroupVersion` store fleet-update metadata. `SystemSetting` is keyed by string. `AdminUser` has a unique `Username`.
+`PlainSightDbContext` manages 18 entity types. `Device.DeviceId` (string, unique) is the natural key used in all player/API interactions. `ContentItem.FileName` is unique. `Playlist` → `PlaylistItem` with cascade delete; a `PlaylistItem` has exactly one of `ContentItemId` or `AnnouncementId` set (nullable FKs, both cascade, enforced by a `CK_PlaylistItems_ExactlyOneTarget` check constraint added via raw SQL in the `AddAnnouncements` migration). `Schedule` has a `Playlist` FK (cascade) and many `ScheduleTargetGroup` entries. `NdiSource.ServiceName` is unique, and `Device` has a nullable FK to `NdiSource`. `BrandingSchedule` references `BrandingVideo` (cascade). `LogEntry` is bulk-inserted from a bounded channel. `PlayerVersion` and `DeviceGroupVersion` store fleet-update metadata. `SystemSetting` is keyed by string. `AdminUser` has a unique `Username`.
 
-`ContentItem` notable fields: `SourceContentItemId` (int?, FK to self — tracks the original item a transform was derived from), `ThumbnailFileName` (string?, sidecar `_thumb.jpg` generated at upload/sync), `CompanionContentItemId` + `CompanionPosition` (`Before`/`After` — virtual pairing; server expands into playlist at serve time, no baked MP4).
+`ContentItem` notable fields: `SourceContentItemId` (int?, FK to self — tracks the original item a transform was derived from), `ThumbnailFileName` (string?, sidecar `_thumb.jpg` generated at upload/sync).
+
+`Announcement` groups related media (e.g. an event's image and video) under one record: `Title`, `Description?`, `EventDate` (`DateOnly?`), `ExpiresAt` (`DateTime?`, UTC), plus an ordered `AnnouncementMedia` list (`ContentItemId` + `SortOrder`). Replaces the old `ContentItem.CompanionContentItemId`/`CompanionPosition` self-FK pairing (removed in the `AddAnnouncements` migration, which also converts any existing companion pairs into `Announcement`s and repoints their `PlaylistItem`s). Server expands an `Announcement` playlist item into its ordered media at heartbeat/preview time — no baked MP4.
 
 ### Player environment variables
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,7 +83,7 @@ The system consists of three main components:
 - YouTube download with size/duration limits and automatic re-encode
 - AI video generation: Gemini/Veo animation + SVD (ComfyUI) self-hosted option
 - Veo watermark removal via ffmpeg
-- Companion content pairing (play before/after)
+- Announcements: group related media (e.g. an event's image + video) into one ordered playlist item
 
 ### Fleet Operations
 - Device offline email alerts

--- a/docs/guides/ai-media-workflow.md
+++ b/docs/guides/ai-media-workflow.md
@@ -8,7 +8,7 @@ End-to-end flow for generating animated video from static images using AI, then 
 2. Download the generated video and **Upload** it to the Content Library (Video or Image tab).
 3. The Veo output includes a watermark. Click **Remove Watermark** (`eraser` icon) on the new item.
 4. Monitor the **Watermark Removal Queue** — the clean file appears as a new item in the library.
-5. (Optional) Pair the original static image as a **Companion Clip** (Before position) in the watermark-free video's Rename modal. This creates a slide→video sequence in playlists.
+5. (Optional) Create an **Announcement** grouping the original static image and the watermark-free video, image first. This creates a slide→video sequence anywhere the announcement is added to a playlist.
 6. Add to a playlist and schedule.
 
 ## SVD (Stable Video Diffusion) Self-Hosted Alternative
@@ -44,7 +44,7 @@ All SVD settings live under the `Svd:` config section. See [Configuration Refere
 
 ### Post-SVD Workflow
 
-Same as Veo: upload → remove watermark → companion pairing → playlist.
+Same as Veo: upload → remove watermark → group into an announcement → playlist.
 
 ## Watermark Removal
 
@@ -55,11 +55,10 @@ Both Gemini/Veo and some SVD outputs include visible watermarks. The **Remove Wa
 - Output is a new `ContentItem` with `SourceContentItemId` pointing to the original.
 - The original is never modified.
 
-## Companion Pairing
+## Announcements (Image + Video Sequences)
 
-After watermark removal, the original static image can be paired as a companion clip so the video always plays after it in any playlist:
+After watermark removal, the original static image and the clean video can be grouped into an **Announcement** so they always play back-to-back, in order, wherever the announcement is added to a playlist:
 
-1. Open the watermark-free video's Rename modal.
-2. Set **Companion Clip** to the original image.
-3. Set **Companion Position** to **Before**.
-4. Save. Now any playlist containing the video will automatically include the image right before it.
+1. Navigate to **Announcements** and create a new one (title, optional event date/expiration).
+2. **Manage Media** → add the original image, then the watermark-free video.
+3. Add the announcement to a playlist from the playlist's **Add Announcement** list — the server expands its media in order at heartbeat/preview time (no baked MP4).

--- a/docs/guides/content-management.md
+++ b/docs/guides/content-management.md
@@ -49,15 +49,13 @@ Each item in the library table has action buttons:
 | **Edit** (`scissors` icon) | Opens the video editor modal: trim, crop, reverse, speed (0.5x–2.0x), strip audio, compress. Creates a new item. |
 | **Ken Burns** (`film` icon) | Image only. Opens the Ken Burns modal for zoom-pan animation. |
 | **SVD Animate** (`stars` icon) | Image only. Visible only when `Svd:ComfyUiBaseUrl` is configured. |
-| **Rename** (`pencil` icon) | Edit the display name, filename, or set a companion clip to play before/after. |
+| **Rename** (`pencil` icon) | Edit the display name, filename, or duration. |
 | **Remove Watermark** (`eraser` icon) | Removes Veo/Gemini watermarks via ffmpeg. Creates a new item. |
 | **Delete** (`trash` icon) | Admin only. Permanently deletes the file from disk and the database record. |
 
-## Companion Content
+## Announcements
 
-Two content items can be paired so one always plays immediately before or after the other in any playlist. The server expands companion pairs at heartbeat time — no baked MP4 is created.
-
-Set a companion via the Rename modal: choose a **Companion Clip** from the dropdown and select **Before** or **After**.
+Content items can be grouped into an **Announcement** so they always play back-to-back, in order, in any playlist — see [Playlists, Schedules & Branding](playlists-schedules-branding.md#announcements) for how to create and add one.
 
 ## Idle Content
 

--- a/docs/guides/playlists-schedules-branding.md
+++ b/docs/guides/playlists-schedules-branding.md
@@ -24,13 +24,31 @@ Navigate to **Playlists** from the sidebar.
 - Click **Manage Content** on a playlist card.
 - **Current Items**: Drag to reorder (grip handle on each row). Click the trash icon to remove.
 - **Add Content**: Lists all content NOT already in the playlist. Click **Add** on any item.
+- **Add Announcement**: Lists all announcements NOT already in the playlist. Click **Add** on any item.
 - Click **Preview** to see how the playlist will look to viewers.
 - Changes invalidate the schedule cache immediately.
 
 ### Notes
 - Each item shows its duration badge. Set an override duration per item in the Content page's Rename modal.
-- Companion pairs are expanded at heartbeat time — you don't need to add both items manually.
+- An announcement's media is expanded, in order, at heartbeat/preview time — you don't need to add its items individually.
 - Reordering renumbers all items 1-indexed and updates the `UpdatedAt` timestamp.
+
+## Announcements
+
+Navigate to **Announcements** from the sidebar. An announcement groups related media (e.g. an event's image and video) under one title, so it can be added to a playlist as a single item that plays its media back-to-back, in order.
+
+### Creating an Announcement
+- Click **Create New Announcement**.
+- Enter a **Title** and optional **Description**.
+- Optionally set an **Event Date** and **Expires At**.
+- Click **Save Announcement**.
+
+### Managing Media
+- Click **Manage Media** on an announcement card.
+- **Current Media**: Reorder with the up/down arrows. Click the trash icon to remove.
+- **Add Content**: Lists all content NOT already in the announcement. Click **Add** on any item.
+
+Once created, add the announcement to a playlist from that playlist's **Add Announcement** list (see above).
 
 ## Schedules
 

--- a/src/PlainSight.Server/Api/DeviceApi.cs
+++ b/src/PlainSight.Server/Api/DeviceApi.cs
@@ -179,6 +179,8 @@ public static class DeviceApi
                     AssignedApiKey = assignedApiKey,
                     PlaylistItems = activePlaylist?.Items
                         .OrderBy(i => i.Order)
+                        // Skip announcements whose expiration has passed; their media must no longer be served.
+                        .Where(i => !(i.Announcement != null && i.Announcement.ExpiresAt < DateTime.UtcNow))
                         .SelectMany(i => i.Announcement != null
                             ? i.Announcement.Media
                                 .OrderBy(m => m.SortOrder)

--- a/src/PlainSight.Server/Api/DeviceApi.cs
+++ b/src/PlainSight.Server/Api/DeviceApi.cs
@@ -179,19 +179,11 @@ public static class DeviceApi
                     AssignedApiKey = assignedApiKey,
                     PlaylistItems = activePlaylist?.Items
                         .OrderBy(i => i.Order)
-                        .SelectMany(i =>
-                        {
-                            PlaylistItemDto main = new() { FileName = i.ContentItem.FileName, DurationSeconds = i.OverrideDurationSeconds ?? i.ContentItem.DurationSeconds };
-                            if (i.ContentItem.CompanionContentItem == null)
-                            {
-                                return [main];
-                            }
-
-                            PlaylistItemDto companion = new() { FileName = i.ContentItem.CompanionContentItem.FileName, DurationSeconds = i.ContentItem.CompanionContentItem.DurationSeconds };
-                            return i.ContentItem.CompanionPosition == Models.CompanionPosition.Before
-                                ? (IEnumerable<PlaylistItemDto>)[companion, main]
-                                : [main, companion];
-                        })
+                        .SelectMany(i => i.Announcement != null
+                            ? i.Announcement.Media
+                                .OrderBy(m => m.SortOrder)
+                                .Select(m => new PlaylistItemDto { FileName = m.ContentItem.FileName, DurationSeconds = m.ContentItem.DurationSeconds })
+                            : [new PlaylistItemDto { FileName = i.ContentItem!.FileName, DurationSeconds = i.OverrideDurationSeconds ?? i.ContentItem.DurationSeconds }])
                         .ToList(),
                     BrandingItem = branding != null ? new PlaylistItemDto { FileName = branding.FileName, DurationSeconds = branding.DurationSeconds } : null,
                     LiveMode = liveMode,

--- a/src/PlainSight.Server/Components/Layout/NavMenu.razor
+++ b/src/PlainSight.Server/Components/Layout/NavMenu.razor
@@ -53,6 +53,12 @@
         </div>
 
         <div class="nav-item">
+            <NavLink class="nav-link" href="announcements">
+                <i class="bi bi-megaphone"></i> Announcements
+            </NavLink>
+        </div>
+
+        <div class="nav-item">
             <NavLink class="nav-link" href="schedules">
                 <i class="bi bi-calendar-event"></i> Schedules
             </NavLink>

--- a/src/PlainSight.Server/Components/Pages/Announcements.razor
+++ b/src/PlainSight.Server/Components/Pages/Announcements.razor
@@ -1,0 +1,540 @@
+@page "/announcements"
+@rendermode InteractiveServer
+@attribute [Authorize]
+@inject IDbContextFactory<PlainSightDbContext> DbFactory
+@inject ILogger<Announcements> Logger
+@inject ScheduleCache ScheduleCache
+
+<PageTitle>Announcements — PlainSight</PageTitle>
+
+<div class="page-header">
+    <h1>Announcements</h1>
+    <p class="text-muted mb-0">Group related media (e.g. an event's image and video) into a single playlist item</p>
+</div>
+
+<div class="row mb-4">
+    <div class="col-md-12">
+        <button class="btn btn-primary" @onclick="ShowCreateAnnouncement">
+            <i class="bi bi-plus-circle"></i> Create New Announcement
+        </button>
+    </div>
+</div>
+
+@if (showCreateForm)
+{
+    <div class="card mb-4">
+        <div class="card-header">
+            <h5 class="mb-0">@(editingAnnouncementId.HasValue ? "Edit" : "Create") Announcement</h5>
+        </div>
+        <div class="card-body">
+            <div class="mb-3">
+                <label class="form-label">Title</label>
+                <input type="text" class="form-control" @bind="announcementTitle" placeholder="Fall Festival" />
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Description</label>
+                <textarea class="form-control" @bind="announcementDescription" rows="2" placeholder="Optional description"></textarea>
+            </div>
+            <div class="row">
+                <div class="col-md-6 mb-3">
+                    <label class="form-label">Event Date</label>
+                    <input type="date" class="form-control" @bind="announcementEventDate" />
+                </div>
+                <div class="col-md-6 mb-3">
+                    <label class="form-label">Expires At</label>
+                    <input type="datetime-local" class="form-control" @bind="announcementExpiresAt" />
+                </div>
+            </div>
+            <button class="btn btn-primary" @onclick="SaveAnnouncement">
+                <i class="bi bi-save"></i> Save Announcement
+            </button>
+            <button class="btn btn-secondary" @onclick="CancelEdit">
+                Cancel
+            </button>
+        </div>
+    </div>
+}
+
+@if (announcements == null)
+{
+    <p><em>Loading announcements...</em></p>
+}
+else if (announcements.Count == 0)
+{
+    <div class="alert alert-info">
+        <i class="bi bi-info-circle"></i> No announcements created yet.
+    </div>
+}
+else
+{
+    <div class="row">
+        @foreach (Announcement announcement in announcements)
+        {
+            <div class="col-md-6 mb-3">
+                <div class="card">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h5 class="mb-0">@announcement.Title</h5>
+                        <div>
+                            <button class="btn btn-sm btn-outline-primary" @onclick="() => EditAnnouncement(announcement.Id)">
+                                <i class="bi bi-pencil"></i> Edit
+                            </button>
+                            <AuthorizeView Roles="Admin">
+                                <Authorized>
+                                    <button class="btn btn-sm btn-outline-danger" @onclick="() => DeleteAnnouncement(announcement.Id)">
+                                        <i class="bi bi-trash"></i> Delete
+                                    </button>
+                                </Authorized>
+                            </AuthorizeView>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        @if (!string.IsNullOrEmpty(announcement.Description))
+                        {
+                            <p class="text-muted small">@announcement.Description</p>
+                        }
+                        <div class="mb-2">
+                            <strong>Media:</strong> @announcement.Media.Count
+                            @if (announcement.EventDate.HasValue)
+                            {
+                                <span class="badge bg-secondary ms-2">Event: @announcement.EventDate.Value.ToString("yyyy-MM-dd")</span>
+                            }
+                            @if (announcement.ExpiresAt.HasValue)
+                            {
+                                <span class="badge bg-warning text-dark ms-1">Expires: @announcement.ExpiresAt.Value.ToString("yyyy-MM-dd HH:mm")</span>
+                            }
+                        </div>
+                        <button class="btn btn-sm btn-primary" @onclick="() => ManageMedia(announcement.Id)">
+                            <i class="bi bi-collection"></i> Manage Media
+                        </button>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+}
+
+@if (managingAnnouncementId.HasValue && selectedAnnouncement != null)
+{
+    <div class="modal d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Manage Media: @selectedAnnouncement.Title</h5>
+                    <button type="button" class="btn-close" @onclick="CloseManageMedia"></button>
+                </div>
+                <div class="modal-body">
+                    <h6>Current Media (@selectedAnnouncement.Media.Count)</h6>
+                    @if (selectedAnnouncement.Media.Count != 0)
+                    {
+                        <div class="list-group mb-3">
+                            @foreach (AnnouncementMedia media in selectedAnnouncement.Media.OrderBy(m => m.SortOrder))
+                            {
+                                <div class="list-group-item d-flex justify-content-between align-items-center">
+                                    <div>
+                                        <strong>@(media.SortOrder + 1).</strong> @media.ContentItem.Name
+                                        <span class="badge bg-secondary ms-2">@media.ContentItem.DurationSeconds s</span>
+                                        <span class="badge bg-info ms-1">@media.ContentItem.Type</span>
+                                    </div>
+                                    <div>
+                                        <button class="btn btn-sm btn-outline-secondary" @onclick="() => MoveMedia(media.Id, -1)" disabled="@isReordering">
+                                            <i class="bi bi-arrow-up"></i>
+                                        </button>
+                                        <button class="btn btn-sm btn-outline-secondary" @onclick="() => MoveMedia(media.Id, 1)" disabled="@isReordering">
+                                            <i class="bi bi-arrow-down"></i>
+                                        </button>
+                                        <button class="btn btn-sm btn-outline-danger" @onclick="() => RemoveMedia(media.Id)">
+                                            <i class="bi bi-trash"></i>
+                                        </button>
+                                    </div>
+                                </div>
+                            }
+                        </div>
+                    }
+                    else
+                    {
+                        <p class="text-muted">No media in this announcement yet.</p>
+                    }
+
+                    <hr />
+
+                    <h6>Add Content</h6>
+                    @if (availableContent == null)
+                    {
+                        <p><em>Loading available content...</em></p>
+                    }
+                    else if (AvailableContentFiltered.Count == 0)
+                    {
+                        <div class="alert alert-info py-2 small">
+                            <i class="bi bi-check-circle"></i> All content has been added to this announcement.
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="list-group">
+                            @foreach (ContentItem content in AvailableContentFiltered)
+                            {
+                                <div class="list-group-item d-flex justify-content-between align-items-center">
+                                    <div>
+                                        <span>@content.Name</span>
+                                        <span class="badge bg-secondary ms-2">@content.DurationSeconds s</span>
+                                        <span class="badge bg-info ms-1">@content.Type</span>
+                                    </div>
+                                    <button class="btn btn-sm btn-outline-primary" @onclick="() => AddMedia(content.Id)" disabled="@isAddingMedia">
+                                        <i class="bi bi-plus"></i> Add
+                                    </button>
+                                </div>
+                            }
+                        </div>
+                    }
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" @onclick="CloseManageMedia">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
+
+    private async Task<bool> IsAdminAsync()
+    {
+        if (this.AuthState == null)
+        {
+            return false;
+        }
+
+        AuthenticationState state = await this.AuthState;
+        return state.User.IsInRole("Admin");
+    }
+
+    private List<Announcement>? announcements;
+    private List<ContentItem>? availableContent;
+    private bool showCreateForm;
+    private int? editingAnnouncementId;
+    private string announcementTitle = string.Empty;
+    private string announcementDescription = string.Empty;
+    private DateOnly? announcementEventDate;
+    private DateTime? announcementExpiresAt;
+    private int? managingAnnouncementId;
+    private Announcement? selectedAnnouncement;
+    private bool isAddingMedia;
+    private bool isReordering;
+    private List<ContentItem> availableContentFiltered = [];
+
+    private List<ContentItem> AvailableContentFiltered => this.availableContentFiltered;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAnnouncements();
+    }
+
+    private async Task LoadAnnouncements()
+    {
+        try
+        {
+            await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
+            announcements = await context.Announcements
+                .Include(a => a.Media)
+                .OrderByDescending(a => a.UpdatedAt)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading announcements");
+            announcements = [];
+        }
+    }
+
+    private void RecomputeAvailableContentFiltered()
+    {
+        if (this.availableContent == null || this.selectedAnnouncement == null)
+        {
+            this.availableContentFiltered = [];
+            return;
+        }
+
+        HashSet<int> inAnnouncement = this.selectedAnnouncement.Media.Select(m => m.ContentItemId).ToHashSet();
+        this.availableContentFiltered = this.availableContent.Where(c => !inAnnouncement.Contains(c.Id)).ToList();
+    }
+
+    private void ShowCreateAnnouncement()
+    {
+        showCreateForm = true;
+        editingAnnouncementId = null;
+        announcementTitle = string.Empty;
+        announcementDescription = string.Empty;
+        announcementEventDate = null;
+        announcementExpiresAt = null;
+    }
+
+    private void EditAnnouncement(int id)
+    {
+        Announcement? announcement = announcements?.FirstOrDefault(a => a.Id == id);
+        if (announcement == null)
+        {
+            return;
+        }
+
+        showCreateForm = true;
+        editingAnnouncementId = id;
+        announcementTitle = announcement.Title;
+        announcementDescription = announcement.Description ?? string.Empty;
+        announcementEventDate = announcement.EventDate;
+        announcementExpiresAt = announcement.ExpiresAt;
+    }
+
+    private void CancelEdit()
+    {
+        showCreateForm = false;
+        editingAnnouncementId = null;
+    }
+
+    private async Task SaveAnnouncement()
+    {
+        if (string.IsNullOrWhiteSpace(announcementTitle))
+        {
+            Logger.LogWarning("Announcement title is required");
+            return;
+        }
+
+        try
+        {
+            await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
+
+            if (editingAnnouncementId.HasValue)
+            {
+                Announcement? announcement = await context.Announcements.FindAsync(editingAnnouncementId.Value);
+                if (announcement != null)
+                {
+                    announcement.Title = announcementTitle;
+                    announcement.Description = announcementDescription;
+                    announcement.EventDate = announcementEventDate;
+                    announcement.ExpiresAt = announcementExpiresAt;
+                    announcement.UpdatedAt = DateTime.UtcNow;
+                }
+            }
+            else
+            {
+                Announcement announcement = new()
+                {
+                    Title = announcementTitle,
+                    Description = announcementDescription,
+                    EventDate = announcementEventDate,
+                    ExpiresAt = announcementExpiresAt,
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow
+                };
+                context.Announcements.Add(announcement);
+            }
+
+            await context.SaveChangesAsync();
+            showCreateForm = false;
+            editingAnnouncementId = null;
+            await LoadAnnouncements();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error saving announcement");
+        }
+    }
+
+    private async Task DeleteAnnouncement(int id)
+    {
+        if (!await this.IsAdminAsync())
+        {
+            this.Logger.LogWarning("Non-admin user attempted to delete announcement {Id}", id);
+            return;
+        }
+
+        try
+        {
+            await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
+            Announcement? announcement = await context.Announcements.FindAsync(id);
+            if (announcement != null)
+            {
+                context.Announcements.Remove(announcement);
+                await context.SaveChangesAsync();
+                ScheduleCache.Invalidate();
+                await LoadAnnouncements();
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error deleting announcement");
+        }
+    }
+
+    private async Task ManageMedia(int announcementId)
+    {
+        managingAnnouncementId = announcementId;
+        availableContent = null;
+        try
+        {
+            await ReloadSelectedAnnouncementAsync(announcementId);
+
+            await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
+            availableContent = await context.ContentItems.OrderBy(c => c.Name).ToListAsync();
+            this.RecomputeAvailableContentFiltered();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading announcement media");
+        }
+    }
+
+    private async Task ReloadSelectedAnnouncementAsync(int announcementId)
+    {
+        await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
+        selectedAnnouncement = await context.Announcements
+            .Include(a => a.Media)
+            .ThenInclude(m => m.ContentItem)
+            .FirstOrDefaultAsync(a => a.Id == announcementId);
+
+        this.RecomputeAvailableContentFiltered();
+    }
+
+    private void CloseManageMedia()
+    {
+        managingAnnouncementId = null;
+        selectedAnnouncement = null;
+        availableContent = null;
+        this.availableContentFiltered = [];
+    }
+
+    private async Task AddMedia(int contentItemId)
+    {
+        if (!managingAnnouncementId.HasValue)
+        {
+            return;
+        }
+
+        isAddingMedia = true;
+        try
+        {
+            await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
+            Announcement? announcement = await context.Announcements
+                .Include(a => a.Media)
+                .FirstOrDefaultAsync(a => a.Id == managingAnnouncementId.Value);
+
+            if (announcement == null)
+            {
+                return;
+            }
+
+            int nextOrder = announcement.Media.Count != 0 ? announcement.Media.Max(m => m.SortOrder) + 1 : 0;
+
+            context.AnnouncementMedia.Add(new AnnouncementMedia
+            {
+                AnnouncementId = managingAnnouncementId.Value,
+                ContentItemId = contentItemId,
+                SortOrder = nextOrder
+            });
+            announcement.UpdatedAt = DateTime.UtcNow;
+            await context.SaveChangesAsync();
+            ScheduleCache.Invalidate();
+
+            await ReloadSelectedAnnouncementAsync(managingAnnouncementId.Value);
+            await LoadAnnouncements();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error adding media to announcement");
+        }
+        finally
+        {
+            isAddingMedia = false;
+        }
+    }
+
+    private async Task RemoveMedia(int mediaId)
+    {
+        if (!managingAnnouncementId.HasValue)
+        {
+            return;
+        }
+
+        try
+        {
+            await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
+            AnnouncementMedia? media = await context.AnnouncementMedia.FindAsync(mediaId);
+            if (media != null)
+            {
+                context.AnnouncementMedia.Remove(media);
+                Announcement? announcement = await context.Announcements.FindAsync(managingAnnouncementId.Value);
+                if (announcement != null)
+                {
+                    announcement.UpdatedAt = DateTime.UtcNow;
+                }
+
+                await context.SaveChangesAsync();
+                ScheduleCache.Invalidate();
+
+                await ReloadSelectedAnnouncementAsync(managingAnnouncementId.Value);
+                await LoadAnnouncements();
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error removing media from announcement");
+        }
+    }
+
+    private async Task MoveMedia(int mediaId, int direction)
+    {
+        if (!managingAnnouncementId.HasValue || isReordering || selectedAnnouncement == null)
+        {
+            return;
+        }
+
+        List<AnnouncementMedia> ordered = selectedAnnouncement.Media.OrderBy(m => m.SortOrder).ToList();
+        int index = ordered.FindIndex(m => m.Id == mediaId);
+        int targetIndex = index + direction;
+        if (index == -1 || targetIndex < 0 || targetIndex >= ordered.Count)
+        {
+            return;
+        }
+
+        isReordering = true;
+        try
+        {
+            (ordered[targetIndex], ordered[index]) = (ordered[index], ordered[targetIndex]);
+
+            await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
+            List<AnnouncementMedia> dbMedia = await context.AnnouncementMedia
+                .Where(m => m.AnnouncementId == managingAnnouncementId.Value)
+                .ToListAsync();
+
+            Dictionary<int, AnnouncementMedia> mediaMap = dbMedia.ToDictionary(m => m.Id);
+
+            for (int i = 0; i < ordered.Count; i++)
+            {
+                if (mediaMap.TryGetValue(ordered[i].Id, out AnnouncementMedia? dbItem))
+                {
+                    dbItem.SortOrder = i;
+                }
+            }
+
+            Announcement? announcement = await context.Announcements.FindAsync(managingAnnouncementId.Value);
+            if (announcement != null)
+            {
+                announcement.UpdatedAt = DateTime.UtcNow;
+            }
+
+            await context.SaveChangesAsync();
+            ScheduleCache.Invalidate();
+
+            await ReloadSelectedAnnouncementAsync(managingAnnouncementId.Value);
+            await LoadAnnouncements();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error reordering announcement media");
+        }
+        finally
+        {
+            isReordering = false;
+        }
+    }
+}

--- a/src/PlainSight.Server/Components/Pages/Announcements.razor
+++ b/src/PlainSight.Server/Components/Pages/Announcements.razor
@@ -80,7 +80,7 @@ else
                             </button>
                             <AuthorizeView Roles="Admin">
                                 <Authorized>
-                                    <button class="btn btn-sm btn-outline-danger" @onclick="() => DeleteAnnouncement(announcement.Id)">
+                                    <button class="btn btn-sm btn-outline-danger" @onclick="() => ConfirmDelete(announcement)">
                                         <i class="bi bi-trash"></i> Delete
                                     </button>
                                 </Authorized>
@@ -195,6 +195,33 @@ else
     </div>
 }
 
+@if (deleteTarget != null)
+{
+    <div class="modal d-block" tabindex="-1" style="background-color: rgba(0,0,0,0.5);">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Delete Announcement</h5>
+                    <button type="button" class="btn-close" @onclick="CancelDelete"></button>
+                </div>
+                <div class="modal-body">
+                    <p>Delete <strong>@deleteTarget.Title</strong>? This removes it from any playlists that reference it and cannot be undone.</p>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-danger" @onclick="DeleteAnnouncement" disabled="@isDeleting">
+                        @if (isDeleting)
+                        {
+                            <span class="spinner-border spinner-border-sm me-1" role="status"></span>
+                        }
+                        Delete
+                    </button>
+                    <button class="btn btn-secondary" @onclick="CancelDelete">Cancel</button>
+                </div>
+            </div>
+        </div>
+    </div>
+}
+
 @code {
     [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
 
@@ -219,6 +246,8 @@ else
     private DateTime? announcementExpiresAt;
     private int? managingAnnouncementId;
     private Announcement? selectedAnnouncement;
+    private Announcement? deleteTarget;
+    private bool isDeleting;
     private bool isAddingMedia;
     private bool isReordering;
     private List<ContentItem> availableContentFiltered = [];
@@ -340,18 +369,35 @@ else
         }
     }
 
-    private async Task DeleteAnnouncement(int id)
+    private void ConfirmDelete(Announcement announcement)
     {
-        if (!await this.IsAdminAsync())
+        this.deleteTarget = announcement;
+    }
+
+    private void CancelDelete()
+    {
+        this.deleteTarget = null;
+    }
+
+    private async Task DeleteAnnouncement()
+    {
+        if (this.deleteTarget == null)
         {
-            this.Logger.LogWarning("Non-admin user attempted to delete announcement {Id}", id);
             return;
         }
 
+        if (!await this.IsAdminAsync())
+        {
+            this.Logger.LogWarning("Non-admin user attempted to delete announcement {Id}", this.deleteTarget.Id);
+            this.deleteTarget = null;
+            return;
+        }
+
+        this.isDeleting = true;
         try
         {
             await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
-            Announcement? announcement = await context.Announcements.FindAsync(id);
+            Announcement? announcement = await context.Announcements.FindAsync(this.deleteTarget.Id);
             if (announcement != null)
             {
                 context.Announcements.Remove(announcement);
@@ -363,6 +409,11 @@ else
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error deleting announcement");
+        }
+        finally
+        {
+            this.isDeleting = false;
+            this.deleteTarget = null;
         }
     }
 

--- a/src/PlainSight.Server/Components/Pages/Content.razor
+++ b/src/PlainSight.Server/Components/Pages/Content.razor
@@ -507,36 +507,6 @@ else
                             <small class="text-muted">How long this item displays (especially for images).</small>
                         }
                     </div>
-                    <div class="mb-3">
-                        <label class="form-label">Companion Clip</label>
-                        <select class="form-select" @bind="companionContentItemId">
-                            <option value="">— None —</option>
-                            @foreach (ContentItem ci in (contentItems ?? []).OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase))
-                            {
-                                if (ci.Id != renamingItem.Id)
-                                {
-                                    <option value="@ci.Id">@ci.Name (@ci.FileName)</option>
-                                }
-                            }
-                        </select>
-                        <small class="text-muted">An extra clip inserted adjacent to this item in the playlist.</small>
-                    </div>
-                    @if (!string.IsNullOrEmpty(companionContentItemId))
-                    {
-                        <div class="mb-3">
-                            <label class="form-label">Companion Position</label>
-                            <div>
-                                <div class="form-check form-check-inline">
-                                    <input class="form-check-input" type="radio" id="compBefore" name="companionPos" value="Before" checked="@(companionPosition == "Before")" @onchange="@(() => this.companionPosition = "Before")" />
-                                    <label class="form-check-label" for="compBefore">Before</label>
-                                </div>
-                                <div class="form-check form-check-inline">
-                                    <input class="form-check-input" type="radio" id="compAfter" name="companionPos" value="After" checked="@(companionPosition == "After")" @onchange="@(() => this.companionPosition = "After")" />
-                                    <label class="form-check-label" for="compAfter">After</label>
-                                </div>
-                            </div>
-                        </div>
-                    }
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" @onclick="CancelRename">Cancel</button>
@@ -1006,8 +976,6 @@ else
     private string newName = "";
     private string newFileName = "";
     private int newDuration = 10;
-    private string companionContentItemId = "";
-    private string companionPosition = "After";
     private ContentItem? itemToDelete;
     private string youtubeUrl = "";
     private readonly List<YouTubeJobState> youtubeJobs = [];
@@ -1304,8 +1272,6 @@ else
         this.newName = item.Name;
         this.newFileName = Path.GetFileNameWithoutExtension(item.FileName);
         this.newDuration = item.DurationSeconds;
-        this.companionContentItemId = item.CompanionContentItemId?.ToString() ?? "";
-        this.companionPosition = item.CompanionPosition?.ToString() ?? "After";
     }
 
     private void CancelRename()
@@ -1358,18 +1324,6 @@ else
 
             item.Name = newName;
             item.DurationSeconds = newDuration;
-
-            // Guard against self-pairing (the UI hides the item itself, but never trust the posted value).
-            if (int.TryParse(this.companionContentItemId, out int parsedCompanionId) && parsedCompanionId != item.Id)
-            {
-                item.CompanionContentItemId = parsedCompanionId;
-                item.CompanionPosition = Enum.TryParse<CompanionPosition>(this.companionPosition, out CompanionPosition pos) ? pos : CompanionPosition.After;
-            }
-            else
-            {
-                item.CompanionContentItemId = null;
-                item.CompanionPosition = null;
-            }
 
             await context.SaveChangesAsync();
 

--- a/src/PlainSight.Server/Components/Pages/Playlists.razor
+++ b/src/PlainSight.Server/Components/Pages/Playlists.razor
@@ -374,9 +374,11 @@ else
     {
         try
         {
+            DateTime utcNow = DateTime.UtcNow;
             await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
             availableAnnouncements = await context.Announcements
                 .Include(a => a.Media)
+                .Where(a => a.ExpiresAt == null || a.ExpiresAt >= utcNow)
                 .OrderBy(a => a.Title)
                 .ToListAsync();
         }
@@ -572,7 +574,7 @@ else
 
             if (playlist == null) return;
 
-            int nextOrder = playlist.Items.Any() ? playlist.Items.Max(i => i.Order) + 1 : 1;
+            int nextOrder = playlist.Items.Count != 0 ? playlist.Items.Max(i => i.Order) + 1 : 1;
 
             PlaylistItem playlistItem = new()
             {

--- a/src/PlainSight.Server/Components/Pages/Playlists.razor
+++ b/src/PlainSight.Server/Components/Pages/Playlists.razor
@@ -155,8 +155,16 @@ else
                                     <div class="d-flex align-items-center">
                                         <i class="bi bi-grip-vertical me-3 text-muted" style="font-size: 1.2rem;"></i>
                                         <div>
-                                            <strong>@item.Order.</strong> @item.ContentItem.Name
-                                            <span class="badge bg-secondary ms-2">@item.ContentItem.DurationSeconds s</span>
+                                            @if (item.Announcement != null)
+                                            {
+                                                <strong>@item.Order.</strong> @item.Announcement.Title
+                                                <span class="badge bg-info ms-2">Announcement · @item.Announcement.Media.Count media</span>
+                                            }
+                                            else
+                                            {
+                                                <strong>@item.Order.</strong> @item.ContentItem!.Name
+                                                <span class="badge bg-secondary ms-2">@item.ContentItem.DurationSeconds s</span>
+                                            }
                                         </div>
                                     </div>
                                     <button class="btn btn-sm btn-outline-danger"
@@ -212,6 +220,43 @@ else
                             }
                         </div>
                     }
+
+                    <h6 class="mt-3">Add Announcement</h6>
+                    @if (availableAnnouncements == null)
+                    {
+                        <p><em>Loading announcements...</em></p>
+                    }
+                    else if (availableAnnouncements.Count == 0)
+                    {
+                        <div class="alert alert-warning py-2 small">
+                            No announcements available. Create one on the <a href="announcements">Announcements</a> page first.
+                        </div>
+                    }
+                    else if (AvailableAnnouncementsFiltered.Count == 0)
+                    {
+                        <div class="alert alert-info py-2 small">
+                            <i class="bi bi-check-circle"></i> All announcements have been added to this playlist.
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="list-group">
+                            @foreach (Announcement announcement in AvailableAnnouncementsFiltered)
+                            {
+                                <div class="list-group-item d-flex justify-content-between align-items-center">
+                                    <div>
+                                        <span>@announcement.Title</span>
+                                        <span class="badge bg-info ms-1">@announcement.Media.Count media</span>
+                                    </div>
+                                    <button class="btn btn-sm btn-outline-primary"
+                                            @onclick="() => AddAnnouncementToPlaylist(announcement.Id)"
+                                            disabled="@isAddingItem">
+                                        <i class="bi bi-plus"></i> Add
+                                    </button>
+                                </div>
+                            }
+                        </div>
+                    }
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" @onclick="CloseManageItems">Close</button>
@@ -237,6 +282,7 @@ else
 
     private List<Playlist>? playlists;
     private List<ContentItem>? availableContent;
+    private List<Announcement>? availableAnnouncements;
     private bool showCreateForm;
     private int? editingPlaylistId;
     private string playlistName = string.Empty;
@@ -254,19 +300,32 @@ else
     // Cached list of content not already in the open playlist. Recomputed only when the open
     // playlist or the available-content list changes, not on every render.
     private List<ContentItem> availableContentFiltered = [];
+    private List<Announcement> availableAnnouncementsFiltered = [];
 
     private List<ContentItem> AvailableContentFiltered => this.availableContentFiltered;
+    private List<Announcement> AvailableAnnouncementsFiltered => this.availableAnnouncementsFiltered;
 
     private void RecomputeAvailableContentFiltered()
     {
         if (this.availableContent == null || this.selectedPlaylist == null)
         {
             this.availableContentFiltered = [];
-            return;
+        }
+        else
+        {
+            HashSet<int> inPlaylist = this.selectedPlaylist.Items.Where(i => i.ContentItemId.HasValue).Select(i => i.ContentItemId!.Value).ToHashSet();
+            this.availableContentFiltered = this.availableContent.Where(c => !inPlaylist.Contains(c.Id)).ToList();
         }
 
-        HashSet<int> inPlaylist = this.selectedPlaylist.Items.Select(i => i.ContentItemId).ToHashSet();
-        this.availableContentFiltered = this.availableContent.Where(c => !inPlaylist.Contains(c.Id)).ToList();
+        if (this.availableAnnouncements == null || this.selectedPlaylist == null)
+        {
+            this.availableAnnouncementsFiltered = [];
+        }
+        else
+        {
+            HashSet<int> inPlaylist = this.selectedPlaylist.Items.Where(i => i.AnnouncementId.HasValue).Select(i => i.AnnouncementId!.Value).ToHashSet();
+            this.availableAnnouncementsFiltered = this.availableAnnouncements.Where(a => !inPlaylist.Contains(a.Id)).ToList();
+        }
     }
 
     protected override async Task OnInitializedAsync()
@@ -306,6 +365,25 @@ else
         {
             Logger.LogError(ex, "Error loading content items");
             availableContent = [];
+        }
+
+        this.RecomputeAvailableContentFiltered();
+    }
+
+    private async Task LoadAvailableAnnouncements()
+    {
+        try
+        {
+            await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
+            availableAnnouncements = await context.Announcements
+                .Include(a => a.Media)
+                .OrderBy(a => a.Title)
+                .ToListAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading announcements");
+            availableAnnouncements = [];
         }
 
         this.RecomputeAvailableContentFiltered();
@@ -418,10 +496,12 @@ else
     {
         managingPlaylistId = playlistId;
         availableContent = null;
+        availableAnnouncements = null;
         try
         {
             await ReloadSelectedPlaylistAsync(playlistId);
             await LoadAvailableContent();
+            await LoadAvailableAnnouncements();
         }
         catch (Exception ex)
         {
@@ -438,6 +518,10 @@ else
         selectedPlaylist = await context.Playlists
             .Include(p => p.Items)
             .ThenInclude(i => i.ContentItem)
+            .Include(p => p.Items)
+            .ThenInclude(i => i.Announcement)
+            .ThenInclude(a => a!.Media)
+            .ThenInclude(m => m.ContentItem)
             .FirstOrDefaultAsync(p => p.Id == playlistId);
 
         this.RecomputeAvailableContentFiltered();
@@ -451,6 +535,10 @@ else
             selectedPlaylist = await context.Playlists
                 .Include(p => p.Items)
                 .ThenInclude(i => i.ContentItem)
+                .Include(p => p.Items)
+                .ThenInclude(i => i.Announcement)
+                .ThenInclude(a => a!.Media)
+                .ThenInclude(m => m.ContentItem)
                 .FirstOrDefaultAsync(p => p.Id == playlistId);
 
             if (selectedPlaylist != null)
@@ -504,6 +592,53 @@ else
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error adding item to playlist");
+        }
+        finally
+        {
+            isAddingItem = false;
+        }
+    }
+
+    private async Task AddAnnouncementToPlaylist(int announcementId)
+    {
+        if (!managingPlaylistId.HasValue)
+        {
+            return;
+        }
+
+        isAddingItem = true;
+        try
+        {
+            await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
+            Playlist? playlist = await context.Playlists
+                .Include(p => p.Items)
+                .FirstOrDefaultAsync(p => p.Id == managingPlaylistId.Value);
+
+            if (playlist == null)
+            {
+                return;
+            }
+
+            int nextOrder = playlist.Items.Count != 0 ? playlist.Items.Max(i => i.Order) + 1 : 1;
+
+            PlaylistItem playlistItem = new()
+            {
+                PlaylistId = managingPlaylistId.Value,
+                AnnouncementId = announcementId,
+                Order = nextOrder
+            };
+
+            context.PlaylistItems.Add(playlistItem);
+            playlist.UpdatedAt = DateTime.UtcNow;
+            await context.SaveChangesAsync();
+            ScheduleCache.Invalidate();
+
+            await ReloadSelectedPlaylistAsync(managingPlaylistId.Value);
+            await LoadPlaylists();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error adding announcement to playlist");
         }
         finally
         {
@@ -602,7 +737,9 @@ else
         managingPlaylistId = null;
         selectedPlaylist = null;
         availableContent = null;
+        availableAnnouncements = null;
         this.availableContentFiltered = [];
+        this.availableAnnouncementsFiltered = [];
     }
 
     private async Task RemoveFromPlaylist(int playlistItemId)

--- a/src/PlainSight.Server/Components/PlaylistPreviewDialog.razor
+++ b/src/PlainSight.Server/Components/PlaylistPreviewDialog.razor
@@ -100,6 +100,8 @@
     {
         orderedItems = Playlist.Items
             .OrderBy(i => i.Order)
+            // Skip expired announcements so the preview matches what players are actually served.
+            .Where(i => !(i.Announcement != null && i.Announcement.ExpiresAt < DateTime.UtcNow))
             .SelectMany(i => i.Announcement != null
                 ? i.Announcement.Media
                     .OrderBy(m => m.SortOrder)

--- a/src/PlainSight.Server/Components/PlaylistPreviewDialog.razor
+++ b/src/PlainSight.Server/Components/PlaylistPreviewDialog.razor
@@ -30,17 +30,17 @@
                         }
                         else
                         {
-                            <video autoplay muted class="preview-media" @onended="OnVideoEnded" @key="@($"{CurrentItem.Id}-{CurrentItem.ContentItem.FileSizeBytes}")">
+                            <video autoplay muted class="preview-media" @onended="OnVideoEnded" @key="@($"{CurrentItem.ContentItem.Id}-{CurrentItem.ContentItem.FileSizeBytes}")">
                                 <source src="/api/media/content/@CurrentItem.ContentItem.FileName?v=@CurrentItem.ContentItem.FileSizeBytes" type="video/mp4" />
                             </video>
                         }
-                        
+
                         <div class="preview-overlay">
                             <div class="progress-bar-container">
                                 <div class="progress-bar-fill" style="width: @(progress)%"></div>
                             </div>
                             <div class="item-info">
-                                <span class="item-name text-truncate">@CurrentItem.ContentItem.Name</span>
+                                <span class="item-name text-truncate">@CurrentItem.DisplayName</span>
                                 <span class="item-timer ms-2">@Math.Ceiling(remainingTime)s</span>
                             </div>
                         </div>
@@ -77,7 +77,14 @@
     [Parameter] public Playlist Playlist { get; set; } = null!;
     [Parameter] public EventCallback OnClose { get; set; }
 
-    private List<PlaylistItem> orderedItems = [];
+    private sealed class PreviewStep
+    {
+        public required ContentItem ContentItem { get; init; }
+        public required string DisplayName { get; init; }
+        public int? OverrideDurationSeconds { get; init; }
+    }
+
+    private List<PreviewStep> orderedItems = [];
     private int currentIndex;
     private string aspectRatio = "16:9";
     private bool isPaused;
@@ -87,11 +94,18 @@
     private Timer? timer;
     private DateTime lastTick;
 
-    private PlaylistItem? CurrentItem => orderedItems.Count > 0 ? orderedItems[currentIndex] : null;
+    private PreviewStep? CurrentItem => orderedItems.Count > 0 ? orderedItems[currentIndex] : null;
 
     protected override void OnInitialized()
     {
-        orderedItems = Playlist.Items.OrderBy(i => i.Order).ToList();
+        orderedItems = Playlist.Items
+            .OrderBy(i => i.Order)
+            .SelectMany(i => i.Announcement != null
+                ? i.Announcement.Media
+                    .OrderBy(m => m.SortOrder)
+                    .Select(m => new PreviewStep { ContentItem = m.ContentItem, DisplayName = $"{i.Announcement.Title} — {m.ContentItem.Name}" })
+                : [new PreviewStep { ContentItem = i.ContentItem!, DisplayName = i.ContentItem!.Name, OverrideDurationSeconds = i.OverrideDurationSeconds }])
+            .ToList();
         if (orderedItems.Count > 0)
         {
             StartItem(0);

--- a/src/PlainSight.Server/Data/PlainSightDbContext.cs
+++ b/src/PlainSight.Server/Data/PlainSightDbContext.cs
@@ -20,6 +20,8 @@ public class PlainSightDbContext(DbContextOptions<PlainSightDbContext> options) 
     public DbSet<LogEntry> LogEntries => this.Set<LogEntry>();
     public DbSet<BrandingVideo> BrandingVideos => this.Set<BrandingVideo>();
     public DbSet<BrandingSchedule> BrandingSchedules => this.Set<BrandingSchedule>();
+    public DbSet<Announcement> Announcements => this.Set<Announcement>();
+    public DbSet<AnnouncementMedia> AnnouncementMedia => this.Set<AnnouncementMedia>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -65,10 +67,25 @@ public class PlainSightDbContext(DbContextOptions<PlainSightDbContext> options) 
         {
             entity.HasKey(e => e.Id);
             entity.HasIndex(e => e.FileName).IsUnique();
-            entity.HasOne(e => e.CompanionContentItem)
+        });
+
+        modelBuilder.Entity<Announcement>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasMany(e => e.Media)
+                .WithOne(e => e.Announcement)
+                .HasForeignKey(e => e.AnnouncementId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<AnnouncementMedia>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasIndex(e => new { e.AnnouncementId, e.SortOrder });
+            entity.HasOne(e => e.ContentItem)
                 .WithMany()
-                .HasForeignKey(e => e.CompanionContentItemId)
-                .OnDelete(DeleteBehavior.SetNull);
+                .HasForeignKey(e => e.ContentItemId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
 
         modelBuilder.Entity<Playlist>(entity =>
@@ -97,6 +114,14 @@ public class PlainSightDbContext(DbContextOptions<PlainSightDbContext> options) 
         modelBuilder.Entity<PlaylistItem>(entity =>
         {
             entity.HasKey(e => e.Id);
+            entity.HasOne(e => e.ContentItem)
+                .WithMany()
+                .HasForeignKey(e => e.ContentItemId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne(e => e.Announcement)
+                .WithMany()
+                .HasForeignKey(e => e.AnnouncementId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
 
         modelBuilder.Entity<DeviceGroupVersion>(entity =>

--- a/src/PlainSight.Server/Migrations/20260704070550_AddAnnouncements.Designer.cs
+++ b/src/PlainSight.Server/Migrations/20260704070550_AddAnnouncements.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PlainSight.Server.Data;
@@ -11,9 +12,11 @@ using PlainSight.Server.Data;
 namespace PlainSight.Server.Migrations
 {
     [DbContext(typeof(PlainSightDbContext))]
-    partial class PlainSightDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260704070550_AddAnnouncements")]
+    partial class AddAnnouncements
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PlainSight.Server/Migrations/20260704070550_AddAnnouncements.cs
+++ b/src/PlainSight.Server/Migrations/20260704070550_AddAnnouncements.cs
@@ -1,0 +1,216 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace PlainSight.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAnnouncements : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "ContentItemId",
+                table: "PlaylistItems",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddColumn<int>(
+                name: "AnnouncementId",
+                table: "PlaylistItems",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "Announcements",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Title = table.Column<string>(type: "text", nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    EventDate = table.Column<DateOnly>(type: "date", nullable: true),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Announcements", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AnnouncementMedia",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    AnnouncementId = table.Column<int>(type: "integer", nullable: false),
+                    ContentItemId = table.Column<int>(type: "integer", nullable: false),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AnnouncementMedia", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AnnouncementMedia_Announcements_AnnouncementId",
+                        column: x => x.AnnouncementId,
+                        principalTable: "Announcements",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AnnouncementMedia_ContentItems_ContentItemId",
+                        column: x => x.ContentItemId,
+                        principalTable: "ContentItems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlaylistItems_AnnouncementId",
+                table: "PlaylistItems",
+                column: "AnnouncementId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AnnouncementMedia_AnnouncementId_SortOrder",
+                table: "AnnouncementMedia",
+                columns: new[] { "AnnouncementId", "SortOrder" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AnnouncementMedia_ContentItemId",
+                table: "AnnouncementMedia",
+                column: "ContentItemId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PlaylistItems_Announcements_AnnouncementId",
+                table: "PlaylistItems",
+                column: "AnnouncementId",
+                principalTable: "Announcements",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            // Data migration: for every ContentItem that had a companion pair, create an Announcement
+            // grouping the pair (in the original Before/After order) and repoint any PlaylistItem that
+            // referenced the "main" ContentItem at the new Announcement instead, so heartbeat delivery
+            // is preserved losslessly. Must run before the old companion columns are dropped below.
+            migrationBuilder.Sql(@"
+                DO $$
+                DECLARE
+                    r RECORD;
+                    new_announcement_id INTEGER;
+                BEGIN
+                    FOR r IN
+                        SELECT ""Id"" AS main_id, ""Name"" AS main_name, ""CompanionContentItemId"" AS companion_id, ""CompanionPosition"" AS position
+                        FROM ""ContentItems""
+                        WHERE ""CompanionContentItemId"" IS NOT NULL
+                    LOOP
+                        INSERT INTO ""Announcements"" (""Title"", ""CreatedAt"", ""UpdatedAt"")
+                        VALUES (r.main_name, NOW(), NOW())
+                        RETURNING ""Id"" INTO new_announcement_id;
+
+                        IF r.position = 0 THEN
+                            INSERT INTO ""AnnouncementMedia"" (""AnnouncementId"", ""ContentItemId"", ""SortOrder"") VALUES
+                                (new_announcement_id, r.companion_id, 0),
+                                (new_announcement_id, r.main_id, 1);
+                        ELSE
+                            INSERT INTO ""AnnouncementMedia"" (""AnnouncementId"", ""ContentItemId"", ""SortOrder"") VALUES
+                                (new_announcement_id, r.main_id, 0),
+                                (new_announcement_id, r.companion_id, 1);
+                        END IF;
+
+                        UPDATE ""PlaylistItems""
+                        SET ""AnnouncementId"" = new_announcement_id, ""ContentItemId"" = NULL
+                        WHERE ""ContentItemId"" = r.main_id;
+                    END LOOP;
+                END $$;
+            ");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ContentItems_ContentItems_CompanionContentItemId",
+                table: "ContentItems");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ContentItems_CompanionContentItemId",
+                table: "ContentItems");
+
+            migrationBuilder.DropColumn(
+                name: "CompanionContentItemId",
+                table: "ContentItems");
+
+            migrationBuilder.DropColumn(
+                name: "CompanionPosition",
+                table: "ContentItems");
+
+            migrationBuilder.Sql(@"
+                ALTER TABLE ""PlaylistItems"" ADD CONSTRAINT ""CK_PlaylistItems_ExactlyOneTarget""
+                CHECK ((""ContentItemId"" IS NOT NULL AND ""AnnouncementId"" IS NULL) OR (""ContentItemId"" IS NULL AND ""AnnouncementId"" IS NOT NULL));
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Note: rolling back drops Announcements/AnnouncementMedia entirely; companion pairs
+            // are not reconstituted from them (lossy downgrade, same as the scaffolded warning).
+            migrationBuilder.Sql(@"ALTER TABLE ""PlaylistItems"" DROP CONSTRAINT IF EXISTS ""CK_PlaylistItems_ExactlyOneTarget"";");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_PlaylistItems_Announcements_AnnouncementId",
+                table: "PlaylistItems");
+
+            migrationBuilder.DropTable(
+                name: "AnnouncementMedia");
+
+            migrationBuilder.DropTable(
+                name: "Announcements");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PlaylistItems_AnnouncementId",
+                table: "PlaylistItems");
+
+            migrationBuilder.DropColumn(
+                name: "AnnouncementId",
+                table: "PlaylistItems");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ContentItemId",
+                table: "PlaylistItems",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "CompanionContentItemId",
+                table: "ContentItems",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "CompanionPosition",
+                table: "ContentItems",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ContentItems_CompanionContentItemId",
+                table: "ContentItems",
+                column: "CompanionContentItemId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ContentItems_ContentItems_CompanionContentItemId",
+                table: "ContentItems",
+                column: "CompanionContentItemId",
+                principalTable: "ContentItems",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+    }
+}

--- a/src/PlainSight.Server/Models/Announcement.cs
+++ b/src/PlainSight.Server/Models/Announcement.cs
@@ -1,0 +1,14 @@
+namespace PlainSight.Server.Models;
+
+public class Announcement
+{
+    public int Id { get; init; }
+    public string Title { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public DateOnly? EventDate { get; set; }
+    public DateTime? ExpiresAt { get; set; }
+    public DateTime CreatedAt { get; init; }
+    public DateTime UpdatedAt { get; set; }
+
+    public List<AnnouncementMedia> Media { get; init; } = [];
+}

--- a/src/PlainSight.Server/Models/AnnouncementMedia.cs
+++ b/src/PlainSight.Server/Models/AnnouncementMedia.cs
@@ -1,0 +1,12 @@
+namespace PlainSight.Server.Models;
+
+public class AnnouncementMedia
+{
+    public int Id { get; init; }
+    public int AnnouncementId { get; init; }
+    public int ContentItemId { get; init; }
+    public int SortOrder { get; set; }
+
+    public Announcement Announcement { get; init; } = null!;
+    public ContentItem ContentItem { get; init; } = null!;
+}

--- a/src/PlainSight.Server/Models/ContentItem.cs
+++ b/src/PlainSight.Server/Models/ContentItem.cs
@@ -13,9 +13,6 @@ public class ContentItem
     public string? SourceUrl { get; set; }
     public int? SourceContentItemId { get; set; }
     public string? ThumbnailFileName { get; set; }
-    public int? CompanionContentItemId { get; set; }
-    public CompanionPosition? CompanionPosition { get; set; }
-    public ContentItem? CompanionContentItem { get; init; }
 }
 
 public enum ContentType
@@ -23,10 +20,4 @@ public enum ContentType
     Video,
     Image,
     RenderedWebsite
-}
-
-public enum CompanionPosition
-{
-    Before,
-    After
 }

--- a/src/PlainSight.Server/Models/PlaylistItem.cs
+++ b/src/PlainSight.Server/Models/PlaylistItem.cs
@@ -6,11 +6,13 @@ public class PlaylistItem
 {
     public int Id { get; init; }
     public int PlaylistId { get; init; }
-    public int ContentItemId { get; init; }
+    public int? ContentItemId { get; set; }
+    public int? AnnouncementId { get; set; }
     public int Order { get; set; }
     public int? OverrideDurationSeconds { get; set; }
 
     [JsonIgnore]
     public Playlist Playlist { get; init; } = null!;
-    public ContentItem ContentItem { get; init; } = null!;
+    public ContentItem? ContentItem { get; init; }
+    public Announcement? Announcement { get; init; }
 }

--- a/src/PlainSight.Server/Services/ContentSyncService.cs
+++ b/src/PlainSight.Server/Services/ContentSyncService.cs
@@ -78,7 +78,7 @@ public class ContentSyncService(
 
             // Batch clear playlist references first
             List<PlaylistItem> refs = await context.PlaylistItems
-                .Where(pi => itemIdsToRemove.Contains(pi.ContentItemId))
+                .Where(pi => pi.ContentItemId != null && itemIdsToRemove.Contains(pi.ContentItemId.Value))
                 .ToListAsync(cancellationToken);
 
             context.PlaylistItems.RemoveRange(refs);

--- a/src/PlainSight.Server/Services/ScheduleService.cs
+++ b/src/PlainSight.Server/Services/ScheduleService.cs
@@ -26,7 +26,11 @@ public class ScheduleService(IDbContextFactory<PlainSightDbContext> dbFactory, S
             .Include(s => s.Playlist)
             .ThenInclude(p => p.Items)
             .ThenInclude(i => i.ContentItem)
-            .ThenInclude(c => c.CompanionContentItem)
+            .Include(s => s.Playlist)
+            .ThenInclude(p => p.Items)
+            .ThenInclude(i => i.Announcement)
+            .ThenInclude(a => a!.Media)
+            .ThenInclude(m => m.ContentItem)
             .Where(s => s.IsActive &&
                         (!s.TargetGroups.Any() || s.TargetGroups.Any(tg => tg.GroupName == deviceGroup)) &&
                         ((s.ScheduledDate == currentDate) || (s.ScheduledDate == null && (s.DaysOfWeek & dayFlag) != 0)) &&


### PR DESCRIPTION
## Summary
- Adds `Announcement` (Title, Description, EventDate, ExpiresAt) and `AnnouncementMedia` (ordered ContentItem list) entities, replacing the `ContentItem.CompanionContentItemId`/`CompanionPosition` self-FK pairing.
- `PlaylistItem` now has nullable `ContentItemId` and `AnnouncementId` (exactly one set, enforced by a DB check constraint). Heartbeat and the playlist preview dialog both expand an `Announcement` playlist item into its ordered media, same as companion pairs did before.
- New `Announcements` page (create/edit, manage ordered media) and an "Add Announcement" list on the Playlists page's Manage Content modal.
- `AddAnnouncements` migration converts existing companion pairs into `Announcement`s and repoints their `PlaylistItem`s before dropping the old columns — verified against a throwaway Postgres container with seeded companion data (main + companion clip → single Announcement with correct media order; PlaylistItem repointed).
- Removed all companion UI from the Content page's Rename modal.
- Docs (`CLAUDE.md`, `docs/guides/*`, `docs/README.md`) updated to describe Announcements instead of companion pairing.

## Test plan
- [x] `dotnet build` (full solution) succeeds
- [x] `dotnet format --verify-no-changes` passes
- [x] Migration applied end-to-end against a scratch Postgres container seeded with a companion pair + referencing playlist item; confirmed lossless conversion to `Announcement`/`AnnouncementMedia` and `PlaylistItem` repointing
- [ ] Manual UI walkthrough of the new Announcements page and Playlists "Add Announcement" flow (not yet done in a running dev environment)

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)