### PR TITLE
fix: patch OpenApi advisory and store announcement expiry in UTC

### DIFF
--- a/src/PlainSight.Server/Components/Pages/Announcements.razor
+++ b/src/PlainSight.Server/Components/Pages/Announcements.razor
@@ -100,7 +100,7 @@ else
                             }
                             @if (announcement.ExpiresAt.HasValue)
                             {
-                                <span class="badge bg-warning text-dark ms-1">Expires: @announcement.ExpiresAt.Value.ToString("yyyy-MM-dd HH:mm")</span>
+                                <span class="badge bg-warning text-dark ms-1">Expires: @announcement.ExpiresAt.Value.ToLocalString("yyyy-MM-dd HH:mm")</span>
                             }
                         </div>
                         <button class="btn btn-sm btn-primary" @onclick="() => ManageMedia(announcement.Id)">
@@ -311,7 +311,8 @@ else
         announcementTitle = announcement.Title;
         announcementDescription = announcement.Description ?? string.Empty;
         announcementEventDate = announcement.EventDate;
-        announcementExpiresAt = announcement.ExpiresAt;
+        // Stored UTC → wall-clock in the configured SystemTimeZone for the datetime-local input.
+        announcementExpiresAt = announcement.ExpiresAt?.ToLocal();
     }
 
     private void CancelEdit()
@@ -328,6 +329,10 @@ else
             return;
         }
 
+        // The datetime-local input yields a wall-clock value in the configured SystemTimeZone;
+        // convert to UTC for storage (ExpiresAt is a timestamptz column and delivery compares against UtcNow).
+        DateTime? expiresAtUtc = announcementExpiresAt?.ToUtc();
+
         try
         {
             await using PlainSightDbContext context = await DbFactory.CreateDbContextAsync();
@@ -340,7 +345,7 @@ else
                     announcement.Title = announcementTitle;
                     announcement.Description = announcementDescription;
                     announcement.EventDate = announcementEventDate;
-                    announcement.ExpiresAt = announcementExpiresAt;
+                    announcement.ExpiresAt = expiresAtUtc;
                     announcement.UpdatedAt = DateTime.UtcNow;
                 }
             }
@@ -351,7 +356,7 @@ else
                     Title = announcementTitle,
                     Description = announcementDescription,
                     EventDate = announcementEventDate,
-                    ExpiresAt = announcementExpiresAt,
+                    ExpiresAt = expiresAtUtc,
                     CreatedAt = DateTime.UtcNow,
                     UpdatedAt = DateTime.UtcNow
                 };

--- a/src/PlainSight.Server/PlainSight.Server.csproj
+++ b/src/PlainSight.Server/PlainSight.Server.csproj
@@ -11,6 +11,8 @@
   <ItemGroup>
     <PackageReference Include="BCrypt.Net-Next" Version="4.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <!-- Pin above the vulnerable 2.0.0 pulled in transitively by AspNetCore.OpenApi (GHSA-v5pm-xwqc-g5wc). -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
 <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/PlainSight.Server/Services/TimeExtensions.cs
+++ b/src/PlainSight.Server/Services/TimeExtensions.cs
@@ -38,6 +38,16 @@ public static class TimeExtensions
         return utcDateTime.ToLocal().ToString(format);
     }
 
+    /// <summary>
+    /// Interprets a wall-clock value (e.g. from a datetime-local input) as time in the configured
+    /// SystemTimeZone and converts it to UTC for storage. DST-aware.
+    /// </summary>
+    public static DateTime ToUtc(this DateTime localDateTime)
+    {
+        DateTime unspecified = DateTime.SpecifyKind(localDateTime, DateTimeKind.Unspecified);
+        return TimeZoneInfo.ConvertTimeToUtc(unspecified, localTimeZone);
+    }
+
     public static string GetTimeZoneName() => localTimeZone.DisplayName;
 
     /// <summary>

--- a/src/PlainSight.Server/appsettings.json
+++ b/src/PlainSight.Server/appsettings.json
@@ -25,7 +25,7 @@
     "SyncWithStreaming": true,
     "SyncWithRecording": true
   },
-  "SystemTimeZone": "Pacific Standard Time",
+  "SystemTimeZone": "America/Los_Angeles",
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
## Summary
Follow-up to #115 addressing two items raised in review.

**1. NuGet high-severity advisory (GHSA-v5pm-xwqc-g5wc)**
`Microsoft.AspNetCore.OpenApi` 10.0.9 pulls in `Microsoft.OpenApi` 2.0.0 transitively, which is vulnerable (circular schema references can terminate OpenAPI parsing). Pinned a direct reference to the first patched version **2.7.5**. `dotnet list package --vulnerable --include-transitive` now reports no vulnerable packages.

**2. `Announcement.ExpiresAt` timezone / storage bug**
`ExpiresAt` is a `timestamp with time zone` column, but the `datetime-local` input produced a `DateTime` with `Kind=Unspecified`. That value:
- mis-compared against `DateTime.UtcNow` in the expiry filters (off by the server's UTC offset), and
- would actually throw at write time under Npgsql (timestamptz requires `Kind=Utc`).

Fix:
- New `TimeExtensions.ToUtc` interprets the entered wall-clock time in the configured `SystemTimeZone` and converts to UTC (DST-aware).
- `SaveAnnouncement` stores UTC; `EditAnnouncement` converts back to local for the input; the card badge now renders local time via `ToLocalString`.
- `SystemTimeZone` set to the IANA id **`America/Los_Angeles`**. The docs already specify an IANA id, and the previous Windows id `"Pacific Standard Time"` is not resolvable on the Linux Docker server (it silently fell back to the container's local zone). Verified `America/Los_Angeles` resolves on .NET 10 and converts July wall-clock at UTC-7 (DST-aware).

## Test plan
- [x] `dotnet build PlainSight.slnx` succeeds, no `NU1903`
- [x] `dotnet list package --vulnerable --include-transitive` → no vulnerable packages
- [x] `dotnet format --verify-no-changes` passes on changed files
- [x] IANA id resolution + DST-aware conversion verified on .NET 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
